### PR TITLE
[ENH] Moving code to import obj | GEN-10770 GEN-11499

### DIFF
--- a/subsurface/core/structs/unstructured_elements/triangular_surface.py
+++ b/subsurface/core/structs/unstructured_elements/triangular_surface.py
@@ -46,8 +46,12 @@ class TriSurf:
         self.texture_point_v = kwargs.get('texture_point_v', None)
 
     @property
-    def has_texture_data(self):
+    def has_texture_data_without_uv(self):
         return self.texture is not None and self.texture_origin is not None and self.texture_point_u is not None and self.texture_point_v is not None
+    
+    @property
+    def has_texture_data_with_uv(self):
+        return 'u' in self.mesh.points_attributes and 'v' in self.mesh.points_attributes
     
     @property
     def triangles(self):

--- a/subsurface/modules/reader/mesh/_trimesh_reader.py
+++ b/subsurface/modules/reader/mesh/_trimesh_reader.py
@@ -173,10 +173,15 @@ def _extract_texture_from_material(geom):
     array = np.empty(0)
     if isinstance(geom.visual.material, trimesh.visual.material.SimpleMaterial):
         image: JpegImageFile = geom.visual.material.image
+        if image is None:
+            return None
         array = np.array(image)
     elif isinstance(geom.visual.material, trimesh.visual.material.PBRMaterial):
         image: PngImageFile = geom.visual.material.baseColorTexture
         array = np.array(image.convert('RGBA'))
+
+        if image is None:
+            return None
     else:
         raise ValueError(f"Unsupported material type: {type(geom.visual.material)}")
 

--- a/subsurface/modules/reader/mesh/_trimesh_reader.py
+++ b/subsurface/modules/reader/mesh/_trimesh_reader.py
@@ -1,0 +1,226 @@
+from typing import Union
+
+import numpy as np
+from subsurface.core.structs import UnstructuredData
+
+import subsurface
+from subsurface import optional_requirements, StructuredData, TriSurf
+
+
+def _load_with_trimesh(path_to_obj, plot = False):
+    trimesh = optional_requirements.require_trimesh()
+    # Load the OBJ with Trimesh using the specified options
+    scene_or_mesh = trimesh.load(path_to_obj)
+    # Process single mesh vs. scene
+    if isinstance(scene_or_mesh, trimesh.Scene):
+        print("Loaded a Scene with multiple geometries.")
+        _process_scene(scene_or_mesh)
+        if plot:
+            scene_or_mesh.show()
+    else:
+        print("Loaded a single Trimesh object.")
+        print(f" - Vertices: {len(scene_or_mesh.vertices)}")
+        print(f" - Faces: {len(scene_or_mesh.faces)}")
+        _handle_material_info(scene_or_mesh)
+        if plot:
+            scene_or_mesh.show()
+    return scene_or_mesh
+
+
+def trimesh_to_unstruct(scene_or_mesh: Union["trimesh.Trimesh", "trimesh.Scene"]) -> subsurface.TriSurf:
+    """
+    Convert a Trimesh or Scene object to a subsurface TriSurf object.
+
+    This function takes either a `trimesh.Trimesh` object or a `trimesh.Scene` 
+    object and converts it to a `subsurface.TriSurf` object. If the input is 
+    a scene containing multiple geometries, it processes all geometries and 
+    combines them into a single TriSurf object. If the input is a single 
+    Trimesh object, it directly converts it to a TriSurf object. An error 
+    is raised if the input is neither a `trimesh.Trimesh` nor a `trimesh.Scene` 
+    object.
+
+    Parameters:
+        scene_or_mesh (Union[trimesh.Trimesh, trimesh.Scene]): 
+            Input geometry data, either as a Trimesh object representing 
+            a single mesh or a Scene object containing multiple geometries.
+
+    Note:
+        ! Multimesh with multiple materials will read the uvs but not the textures since in that case is better
+        ! to read directly the multiple images (compressed) whenever the user wants to work with them. 
+
+    Returns:
+        subsurface.TriSurf: Converted subsurface representation of the 
+        provided geometry data.
+
+    Raises:
+        ValueError: If the input is neither a `trimesh.Trimesh` object nor 
+        a `trimesh.Scene` object.
+    """
+    trimesh = optional_requirements.require_trimesh()
+    if isinstance(scene_or_mesh, trimesh.Scene):
+        # Process scene with multiple geometries
+        ts = _trisurf_from_scene(scene_or_mesh, trimesh)
+
+    elif isinstance(scene_or_mesh, trimesh.Trimesh):
+        ts = _trisurf_from_trimesh(scene_or_mesh)
+
+
+    else:
+        raise ValueError("Input must be a Trimesh object or a Scene with multiple geometries.")
+
+    return ts
+
+
+def _trisurf_from_trimesh(scene_or_mesh):
+    # Process single mesh
+    tri = scene_or_mesh
+    pandas = optional_requirements.require_pandas()
+    frame = pandas.DataFrame(tri.face_attributes)
+    # Check frame has a valid shape for cells_attr if not make None
+    if frame.shape[0] != tri.faces.shape[0]:
+        frame = None
+    # Get UV coordinates if they exist
+    vertex_attr = None
+    if hasattr(tri.visual, 'uv') and tri.visual.uv is not None:
+        vertex_attr = pandas.DataFrame(
+            tri.visual.uv,
+            columns=['u', 'v']
+        )
+    unstruct = UnstructuredData.from_array(
+        np.array(tri.vertices),
+        np.array(tri.faces),
+        cells_attr=frame,
+        vertex_attr=vertex_attr,
+        xarray_attributes={
+                "bounds": tri.bounds.tolist(),
+        },
+    )
+
+    texture = _extract_texture_from_material(tri)
+
+    ts = TriSurf(
+        mesh=unstruct,
+        texture=texture,
+    )
+    return ts
+
+
+def _trisurf_from_scene(scene_or_mesh: 'Scene', trimesh: 'trimesh') -> subsurface.TriSurf:
+    pandas = optional_requirements.require_pandas()
+    geometries = scene_or_mesh.geometry
+    assert len(geometries) > 0, "No geometries found in the scene."
+    all_vertex = []
+    all_cells = []
+    cell_attr = []
+    all_vertex_attr = []
+    _last_cell = 0
+    texture = None
+    for i, (geom_name, geom) in enumerate(geometries.items()):
+        geom: trimesh.Trimesh
+        _handle_material_info(geom)
+
+        # Append vertices
+        all_vertex.append(np.array(geom.vertices))
+
+        # Adjust cell indices and append
+        cells = np.array(geom.faces)
+        if len(all_cells) > 0:
+            cells = cells + _last_cell
+        all_cells.append(cells)
+
+        # Create attribute array for this geometry
+        cell_attr.append(np.ones(len(cells)) * i)
+
+        _last_cell = cells.max() + 1
+
+        # Get UV coordinates if they exist
+        if hasattr(geom.visual, 'uv') and geom.visual.uv is not None:
+            vertex_attr = pandas.DataFrame(
+                geom.visual.uv,
+                columns=['u', 'v']
+            )
+            all_vertex_attr.append(vertex_attr)
+
+        # Extract texture from material if it is only one geometry
+        if len(geometries) == 1:
+            texture = _extract_texture_from_material(geom)
+
+    # Create the combined UnstructuredData
+    unstruct = UnstructuredData.from_array(
+        vertex=np.vstack(all_vertex),
+        cells=np.vstack(all_cells),
+        vertex_attr=pandas.concat(all_vertex_attr, ignore_index=True) if all_vertex_attr is not None else None,
+        cells_attr=pandas.DataFrame(np.hstack(cell_attr), columns=["Geometry id"]),
+        xarray_attributes={
+                "bounds": scene_or_mesh.bounds.tolist(),
+        },
+    )
+
+    # If there is a texture
+    ts = TriSurf(
+        mesh=unstruct,
+        texture=texture,
+    )
+
+    return ts
+
+
+def _extract_texture_from_material(geom):
+    from PIL.JpegImagePlugin import JpegImageFile
+    from PIL.PngImagePlugin import PngImageFile
+    import trimesh
+
+    array = np.empty(0)
+    if isinstance(geom.visual.material, trimesh.visual.material.SimpleMaterial):
+        image: JpegImageFile = geom.visual.material.image
+        array = np.array(image)
+    elif isinstance(geom.visual.material, trimesh.visual.material.PBRMaterial):
+        image: PngImageFile = geom.visual.material.baseColorTexture
+        array = np.array(image.convert('RGBA'))
+    else:
+        raise ValueError(f"Unsupported material type: {type(geom.visual.material)}")
+
+    # Asser that image has 3 channels    assert array.shape[2] == 3    from PIL.PngImagePlugin import PngImageFile
+    assert array.shape[2] == 3 or array.shape[2] == 4
+    texture = StructuredData.from_numpy(array)
+    return texture
+
+
+def _validate_texture_path(texture_path):
+    """Validate the texture file path."""
+    if texture_path and not texture_path.lower().endswith(('.png', '.jpg', '.jpeg')):
+        raise ValueError("Texture path must be a PNG or JPEG file")
+
+
+def _handle_material_info(geometry):
+    """
+    Handle and print material information for a single geometry,
+    explicitly injecting the PIL image if provided.
+    """
+    if geometry.visual and hasattr(geometry.visual, 'material'):
+        material = geometry.visual.material
+
+        print("Trimesh material:", material)
+
+        # If there's already an image reference in the material, let the user know
+        if hasattr(material, 'image') and material.image is not None:
+            print("  -> Material already has an image:", material.image)
+    else:
+        print("No material found or no 'material' attribute on this geometry.")
+
+
+def _process_scene(scene):
+    """Process a scene with multiple geometries."""
+    geometries = scene.geometry
+    assert len(geometries) > 0, "No geometries found in the scene."
+
+    print(f"Loaded a Scene with {len(scene.geometry)} geometry object(s).")
+    for geom_name, geom in geometries.items():
+        print(f" Submesh: {geom_name}")
+        print(f"  - Vertices: {len(geom.vertices)}")
+        print(f"  - Faces: {len(geom.faces)}")
+
+        print(f"Geometry '{geom_name}':")
+        _handle_material_info(geom)
+
+

--- a/subsurface/modules/reader/mesh/_trimesh_reader.py
+++ b/subsurface/modules/reader/mesh/_trimesh_reader.py
@@ -7,7 +7,7 @@ import subsurface
 from subsurface import optional_requirements, StructuredData, TriSurf
 
 
-def _load_with_trimesh(path_to_obj, plot = False):
+def _load_with_trimesh(path_to_obj, plot=False):
     trimesh = optional_requirements.require_trimesh()
     # Load the OBJ with Trimesh using the specified options
     scene_or_mesh = trimesh.load(path_to_obj)
@@ -149,7 +149,7 @@ def _trisurf_from_scene(scene_or_mesh: 'Scene', trimesh: 'trimesh') -> subsurfac
     unstruct = UnstructuredData.from_array(
         vertex=np.vstack(all_vertex),
         cells=np.vstack(all_cells),
-        vertex_attr=pandas.concat(all_vertex_attr, ignore_index=True) if all_vertex_attr is not None else None,
+        vertex_attr=pandas.concat(all_vertex_attr, ignore_index=True) if len(all_vertex_attr) > 0 else None,
         cells_attr=pandas.DataFrame(np.hstack(cell_attr), columns=["Geometry id"]),
         xarray_attributes={
                 "bounds": scene_or_mesh.bounds.tolist(),
@@ -222,5 +222,3 @@ def _process_scene(scene):
 
         print(f"Geometry '{geom_name}':")
         _handle_material_info(geom)
-
-

--- a/subsurface/modules/reader/mesh/glb_reader.py
+++ b/subsurface/modules/reader/mesh/glb_reader.py
@@ -1,10 +1,27 @@
-from typing import Union
-
-import numpy as np
-from subsurface.core.structs import UnstructuredData
-
 import subsurface
-from subsurface import optional_requirements, StructuredData, TriSurf
+from subsurface.modules.reader.mesh._trimesh_reader import _load_with_trimesh, trimesh_to_unstruct
 
-def load_obj_with_trimesh(path_to_obj: str, plot: bool = False) -> Union["trimesh.Trimesh", "trimesh.Scene"]:
-    raise NotImplementedError
+
+def load_glb_with_trimesh(path_to_glb: str, plot: bool = False) -> subsurface.TriSurf:
+    """
+    load_obj_with_trimesh(path_to_glb, plot=False)
+
+    Loads a 3D object file in .glb format using trimesh, processes it, and converts it into 
+    a subsurface TriSurf object for further analysis or usage. Optionally, it allows 
+    plotting the loaded object.
+
+    Parameters
+    ----------
+    path_to_glb : str
+        Path to the .glb file containing the 3D object.
+    plot : bool, optional
+        A flag indicating whether the loaded 3D object should be plotted. Defaults to False.
+
+    Returns
+    -------
+    subsurface.TriSurf
+        A TriSurf object representing the processed 3D surface geometry.
+    """
+    trimesh = _load_with_trimesh(path_to_glb, plot)
+    trisurf = trimesh_to_unstruct(trimesh)
+    return trisurf

--- a/subsurface/modules/reader/mesh/glb_reader.py
+++ b/subsurface/modules/reader/mesh/glb_reader.py
@@ -1,0 +1,10 @@
+from typing import Union
+
+import numpy as np
+from subsurface.core.structs import UnstructuredData
+
+import subsurface
+from subsurface import optional_requirements, StructuredData, TriSurf
+
+def load_obj_with_trimesh(path_to_obj: str, plot: bool = False) -> Union["trimesh.Trimesh", "trimesh.Scene"]:
+    raise NotImplementedError

--- a/subsurface/modules/reader/mesh/obj_reader.py
+++ b/subsurface/modules/reader/mesh/obj_reader.py
@@ -1,3 +1,67 @@
 ﻿import pyvista as pv
 import numpy as np
 import os
+
+from subsurface import optional_requirements
+
+
+def load_obj_with_trimesh(path_to_obj, plot=False):
+    """
+    Load an OBJ file with optional texture path override.
+    We explicitly inject the texture into each geometry's material
+    if a texture_path is provided.
+    """
+    trimesh = optional_requirements.require_trimesh()
+
+    # Load the OBJ with Trimesh, ignoring material_imgpath
+    # because it often doesn't override properly for Wavefront
+    # Prepare load options
+    # If the user explicitly provides a texture, we tell Trimesh
+
+    # Load the OBJ with Trimesh using the specified options
+    scene_or_mesh = trimesh.load(path_to_obj)
+
+    # Process single mesh vs. scene
+    if isinstance(scene_or_mesh, trimesh.Scene):
+        print("Loaded a Scene with multiple geometries.")
+        _process_scene(scene_or_mesh)
+        if plot:
+            scene_or_mesh.show()
+    else:
+        print("Loaded a single Trimesh.")
+        _handle_material_info(scene_or_mesh)
+        if plot:
+            scene_or_mesh.show()
+
+
+def _validate_texture_path(texture_path):
+    """Validate the texture file path."""
+    if texture_path and not texture_path.lower().endswith(('.png', '.jpg', '.jpeg')):
+        raise ValueError("Texture path must be a PNG or JPEG file")
+
+
+def _handle_material_info(geometry):
+    """
+    Handle and print material information for a single geometry,
+    explicitly injecting the PIL image if provided.
+    """
+    if geometry.visual and hasattr(geometry.visual, 'material'):
+        material = geometry.visual.material
+
+        print("Trimesh material:", material)
+
+        # If there's already an image reference in the material, let the user know
+        if hasattr(material, 'image') and material.image is not None:
+            print("  -> Material already has an image:", material.image)
+    else:
+        print("No material found or no 'material' attribute on this geometry.")
+
+
+def _process_scene(scene):
+    """Process a scene with multiple geometries."""
+    geometries = scene.geometry
+    assert len(geometries) > 0, "No geometries found in the scene."
+
+    for geom_name, geom in geometries.items():
+        print(f"Geometry '{geom_name}':")
+        _handle_material_info(geom)

--- a/subsurface/modules/reader/mesh/obj_reader.py
+++ b/subsurface/modules/reader/mesh/obj_reader.py
@@ -1,22 +1,40 @@
-﻿import pyvista as pv
+﻿from typing import Union
+
 import numpy as np
-import os
+import pandas
 
-from subsurface import optional_requirements
+from subsurface.core.structs import UnstructuredData
+
+import subsurface
+from subsurface import optional_requirements, StructuredData, TriSurf
 
 
-def load_obj_with_trimesh(path_to_obj, plot=False):
+def load_obj_with_trimesh(path_to_obj: str, plot: bool = False) -> Union["trimesh.Trimesh", "trimesh.Scene"]:
     """
-    Load an OBJ file with optional texture path override.
-    We explicitly inject the texture into each geometry's material
-    if a texture_path is provided.
+    Summary:
+        Loads an OBJ file using Trimesh, processes it as either a single mesh or a 
+        scene with multiple geometries, and optionally displays the result. The 
+        function differentiates between single mesh and scene processing, applying 
+        specific handling based on the loaded object's type.
+    
+    Note: 
+        ! This is missing the option to force a png as texture from code. trimesh ignores the uv when the
+        ! material does not have an image. This is a limitation of trimesh. We could rewrite the load obj
+        ! function in trimesh to allow that
+
+    Arguments:
+        path_to_obj: str
+            Path to the .obj file to be loaded.
+        plot: bool, optional
+            Flag indicating whether to display the loaded object using Trimesh's 
+            visualization tools. Defaults to False.
+
+    Returns:
+        Union[trimesh.Trimesh, trimesh.Scene]
+            Returns the loaded Trimesh object as either a single mesh or a scene 
+            containing multiple geometries.
     """
     trimesh = optional_requirements.require_trimesh()
-
-    # Load the OBJ with Trimesh, ignoring material_imgpath
-    # because it often doesn't override properly for Wavefront
-    # Prepare load options
-    # If the user explicitly provides a texture, we tell Trimesh
 
     # Load the OBJ with Trimesh using the specified options
     scene_or_mesh = trimesh.load(path_to_obj)
@@ -32,6 +50,96 @@ def load_obj_with_trimesh(path_to_obj, plot=False):
         _handle_material_info(scene_or_mesh)
         if plot:
             scene_or_mesh.show()
+    
+    return scene_or_mesh
+
+
+def trimesh_obj_to_unstruct(scene_or_mesh: Union["trimesh.Trimesh", "trimesh.Scene"]) -> subsurface.UnstructuredData:
+    trimesh = optional_requirements.require_trimesh()
+    if isinstance(scene_or_mesh, trimesh.Scene):
+        # Process scene with multiple geometries
+        unstruct = _unstruct_from_scene(scene_or_mesh, trimesh)
+
+    elif isinstance(scene_or_mesh, trimesh.Trimesh):
+        # Process single mesh
+        tri = scene_or_mesh
+        frame = pandas.DataFrame(tri.face_attributes)
+        # Check frame has a valid shape for cells_attr if not make None
+        if frame.shape[0] != tri.faces.shape[0]:
+            frame = None
+            
+        # Get UV coordinates if they exist
+        vertex_attr = None
+        if hasattr(tri.visual, 'uv') and tri.visual.uv is not None:
+            vertex_attr = pandas.DataFrame(
+                tri.visual.uv,
+                columns=['u', 'v']
+            )
+        
+        unstruct = UnstructuredData.from_array(
+            np.array(tri.vertices),
+            np.array(tri.faces),
+            cells_attr=frame,
+            vertex_attr=vertex_attr,
+            xarray_attributes={
+                "bounds": tri.bounds.tolist(),
+            },
+        )
+        
+        # If there is a texture
+        texture = StructuredData.from_numpy(tri.visual.material.image)
+        coords = tri.vertices
+
+        ts = TriSurf(
+            mesh=unstruct,
+            texture=texture,
+            # texture_origin=[coords[0][0], coords[0][1], zmin],
+            # texture_point_u=[coords[-1][0], coords[-1][1], zmin],
+            # texture_point_v=[coords[0][0], coords[0][1], zmax]
+        )
+
+
+    else:
+        raise ValueError("Input must be a Trimesh object or a Scene with multiple geometries.")
+        
+    return unstruct
+
+
+def _unstruct_from_scene(scene_or_mesh: 'Scene', trimesh: 'trimesh') -> 'UnstructuredData':
+    import pandas as pd
+    geometries = scene_or_mesh.geometry
+    assert len(geometries) > 0, "No geometries found in the scene."
+    all_vertex = []
+    all_cells = []
+    cell_attr = []
+    _last_cell = 0
+    for i, (geom_name, geom) in enumerate(geometries.items()):
+        geom: trimesh.Trimesh
+        _handle_material_info(geom)
+
+        # Append vertices
+        all_vertex.append(np.array(geom.vertices))
+
+        # Adjust cell indices and append
+        cells = np.array(geom.faces)
+        if len(all_cells) > 0:
+            cells = cells + _last_cell
+        all_cells.append(cells)
+
+        # Create attribute array for this geometry
+        cell_attr.append(np.ones(len(cells)) * i)
+
+        _last_cell = cells.max() + 1
+    # Create the combined UnstructuredData
+    unstruct = UnstructuredData.from_array(
+        vertex=np.vstack(all_vertex),
+        cells=np.vstack(all_cells),
+        cells_attr=pd.DataFrame(np.hstack(cell_attr), columns=["Geometry id"]),
+        xarray_attributes={
+                "bounds": scene_or_mesh.bounds.tolist(),
+        },
+    )
+    return unstruct
 
 
 def _validate_texture_path(texture_path):

--- a/subsurface/modules/reader/mesh/obj_reader.py
+++ b/subsurface/modules/reader/mesh/obj_reader.py
@@ -1,253 +1,39 @@
 ﻿from typing import Union
 
-import numpy as np
-from subsurface.core.structs import UnstructuredData
-
 import subsurface
-from subsurface import optional_requirements, StructuredData, TriSurf
+from subsurface.modules.reader.mesh._trimesh_reader import _load_with_trimesh, trimesh_to_unstruct
 
 
-def load_obj_with_trimesh(path_to_obj: str, plot: bool = False) -> Union["trimesh.Trimesh", "trimesh.Scene"]:
+def load_obj_with_trimesh(path_to_obj: str, plot: bool = False) -> subsurface.TriSurf:
     """
-    Summary:
-        Loads an OBJ file using Trimesh, processes it as either a single mesh or a 
-        scene with multiple geometries, and optionally displays the result. The 
-        function differentiates between single mesh and scene processing, applying 
-        specific handling based on the loaded object's type.
-    
+    Load and process an OBJ file, returning trimesh-compatible objects.
+
+    This function loads an OBJ file using `trimesh`, optionally plots it,
+    and converts the loaded mesh or scene into a suitable unstructured format
+    using the `trimesh_to_unstruct` function. Depending on the input and the 
+    contents of the OBJ file, it may return a Trimesh object or a Scene object.
+
     Note: 
-        ! This is missing the option to force a png as texture from code. trimesh ignores the uv when the
-        ! material does not have an image. This is a limitation of trimesh. We could rewrite the load obj
-        ! function in trimesh to allow that
+    This implementation does not include the capability to force a PNG as a 
+    texture if the material does not already have an associated image. 
+    `trimesh` ignores UVs when this condition occurs. Modifications to 
+    `trimesh`'s loading function would be necessary to address this limitation.
 
-    Arguments:
-        path_to_obj: str
-            Path to the .obj file to be loaded.
-        plot: bool, optional
-            Flag indicating whether to display the loaded object using Trimesh's 
-            visualization tools. Defaults to False.
-
-    Returns:
-        Union[trimesh.Trimesh, trimesh.Scene]
-            Returns the loaded Trimesh object as either a single mesh or a scene 
-            containing multiple geometries.
-    """
-    trimesh = optional_requirements.require_trimesh()
-
-    # Load the OBJ with Trimesh using the specified options
-    scene_or_mesh = trimesh.load(path_to_obj)
-
-    # Process single mesh vs. scene
-    if isinstance(scene_or_mesh, trimesh.Scene):
-        print("Loaded a Scene with multiple geometries.")
-        _process_scene(scene_or_mesh)
-        if plot:
-            scene_or_mesh.show()
-    else:
-        print("Loaded a single Trimesh object.")
-        print(f" - Vertices: {len(scene_or_mesh.vertices)}")
-        print(f" - Faces: {len(scene_or_mesh.faces)}")
-        _handle_material_info(scene_or_mesh)
-        if plot:
-            scene_or_mesh.show()
-    
-    return scene_or_mesh
-
-
-def trimesh_obj_to_unstruct(scene_or_mesh: Union["trimesh.Trimesh", "trimesh.Scene"]) -> subsurface.TriSurf:
-    """
-    Convert a Trimesh or Scene object to a subsurface TriSurf object.
-
-    This function takes either a `trimesh.Trimesh` object or a `trimesh.Scene` 
-    object and converts it to a `subsurface.TriSurf` object. If the input is 
-    a scene containing multiple geometries, it processes all geometries and 
-    combines them into a single TriSurf object. If the input is a single 
-    Trimesh object, it directly converts it to a TriSurf object. An error 
-    is raised if the input is neither a `trimesh.Trimesh` nor a `trimesh.Scene` 
-    object.
-
-    Parameters:
-        scene_or_mesh (Union[trimesh.Trimesh, trimesh.Scene]): 
-            Input geometry data, either as a Trimesh object representing 
-            a single mesh or a Scene object containing multiple geometries.
-    
-    Note:
-        ! Multimesh with multiple materials will read the uvs but not the textures since in that case is better
-        ! to read directly the multiple images (compressed) whenever the user wants to work with them. 
+    Args:
+        path_to_obj: Path to the OBJ file to be loaded.
+                     This must be a valid file path to a 3D object in OBJ format.
+        plot: Boolean flag indicating whether to visually plot the loaded model.
+              Defaults to False.
 
     Returns:
-        subsurface.TriSurf: Converted subsurface representation of the 
-        provided geometry data.
+        A `trimesh.Trimesh` object if a single mesh is loaded, or a `trimesh.Scene`
+        object if the file contains multiple meshes or a scene.
 
     Raises:
-        ValueError: If the input is neither a `trimesh.Trimesh` object nor 
-        a `trimesh.Scene` object.
+        `FileNotFoundError`: If the provided file path does not exist.
+        `ValueError`: If the OBJ file could not be properly processed.
+
     """
-    trimesh = optional_requirements.require_trimesh()
-    if isinstance(scene_or_mesh, trimesh.Scene):
-        # Process scene with multiple geometries
-        ts = _trisurf_from_scene(scene_or_mesh, trimesh)
-
-    elif isinstance(scene_or_mesh, trimesh.Trimesh):
-        ts = _trisurf_from_trimesh(scene_or_mesh)
-
-
-    else:
-        raise ValueError("Input must be a Trimesh object or a Scene with multiple geometries.")
-        
-    return ts
-
-
-def _trisurf_from_trimesh(scene_or_mesh):
-    # Process single mesh
-    tri = scene_or_mesh
-    pandas = optional_requirements.require_pandas()
-    frame = pandas.DataFrame(tri.face_attributes)
-    # Check frame has a valid shape for cells_attr if not make None
-    if frame.shape[0] != tri.faces.shape[0]:
-        frame = None
-    # Get UV coordinates if they exist
-    vertex_attr = None
-    if hasattr(tri.visual, 'uv') and tri.visual.uv is not None:
-        vertex_attr = pandas.DataFrame(
-            tri.visual.uv,
-            columns=['u', 'v']
-        )
-    unstruct = UnstructuredData.from_array(
-        np.array(tri.vertices),
-        np.array(tri.faces),
-        cells_attr=frame,
-        vertex_attr=vertex_attr,
-        xarray_attributes={
-                "bounds": tri.bounds.tolist(),
-        },
-    )
-
-    texture = _extract_texture_from_material(tri)
-    
-    
-    ts = TriSurf(
-        mesh=unstruct,
-        texture=texture,
-    )
-    return ts
-
-
-def _trisurf_from_scene(scene_or_mesh: 'Scene', trimesh: 'trimesh') -> subsurface.TriSurf:
-    pandas = optional_requirements.require_pandas()
-    geometries = scene_or_mesh.geometry
-    assert len(geometries) > 0, "No geometries found in the scene."
-    all_vertex = []
-    all_cells = []
-    cell_attr = []
-    all_vertex_attr = []
-    _last_cell = 0
-    texture = None
-    for i, (geom_name, geom) in enumerate(geometries.items()):
-        geom: trimesh.Trimesh
-        _handle_material_info(geom)
-
-        # Append vertices
-        all_vertex.append(np.array(geom.vertices))
-
-        # Adjust cell indices and append
-        cells = np.array(geom.faces)
-        if len(all_cells) > 0:
-            cells = cells + _last_cell
-        all_cells.append(cells)
-
-        # Create attribute array for this geometry
-        cell_attr.append(np.ones(len(cells)) * i)
-
-        _last_cell = cells.max() + 1
-
-
-        # Get UV coordinates if they exist
-        if hasattr(geom.visual, 'uv') and geom.visual.uv is not None:
-            vertex_attr = pandas.DataFrame(
-                geom.visual.uv,
-                columns=['u', 'v']
-            )
-            all_vertex_attr.append(vertex_attr)
-
-        # Extract texture from material if it is only one geometry
-        if len(geometries) == 1:
-            texture = _extract_texture_from_material(geom)
-
-    # Create the combined UnstructuredData
-    unstruct = UnstructuredData.from_array(
-        vertex=np.vstack(all_vertex),
-        cells=np.vstack(all_cells),
-        vertex_attr=pandas.concat(all_vertex_attr, ignore_index=True) if all_vertex_attr is not None else None,
-        cells_attr=pandas.DataFrame(np.hstack(cell_attr), columns=["Geometry id"]),
-        xarray_attributes={
-                "bounds": scene_or_mesh.bounds.tolist(),
-        },
-    )
-
-    # If there is a texture
-    ts = TriSurf(
-        mesh=unstruct,
-        texture=texture,
-    )
-
-    return ts
-
-
-def _extract_texture_from_material(geom):
-    from PIL.JpegImagePlugin import JpegImageFile
-    from PIL.PngImagePlugin import PngImageFile
-    import trimesh
-    
-    array = np.empty(0)
-    if isinstance(geom.visual.material, trimesh.visual.material.SimpleMaterial):
-        image: JpegImageFile = geom.visual.material.image  
-        array = np.array(image)
-    elif isinstance(geom.visual.material, trimesh.visual.material.PBRMaterial):
-        image: PngImageFile = geom.visual.material.baseColorTexture      
-        array = np.array(image.convert('RGBA'))       
-    else:
-        raise ValueError(f"Unsupported material type: {type(geom.visual.material)}")
-        
-    # Asser that image has 3 channels    assert array.shape[2] == 3    from PIL.PngImagePlugin import PngImageFile
-    assert array.shape[2] == 3 or array.shape[2] == 4
-    texture = StructuredData.from_numpy(array)
-    return texture
-
-
-def _validate_texture_path(texture_path):
-    """Validate the texture file path."""
-    if texture_path and not texture_path.lower().endswith(('.png', '.jpg', '.jpeg')):
-        raise ValueError("Texture path must be a PNG or JPEG file")
-
-
-def _handle_material_info(geometry):
-    """
-    Handle and print material information for a single geometry,
-    explicitly injecting the PIL image if provided.
-    """
-    if geometry.visual and hasattr(geometry.visual, 'material'):
-        material = geometry.visual.material
-
-        print("Trimesh material:", material)
-
-        # If there's already an image reference in the material, let the user know
-        if hasattr(material, 'image') and material.image is not None:
-            print("  -> Material already has an image:", material.image)
-    else:
-        print("No material found or no 'material' attribute on this geometry.")
-
-
-def _process_scene(scene):
-    """Process a scene with multiple geometries."""
-    geometries = scene.geometry
-    assert len(geometries) > 0, "No geometries found in the scene."
-
-    print(f"Loaded a Scene with {len(scene.geometry)} geometry object(s).")
-    for geom_name, geom in geometries.items():
-        print(f" Submesh: {geom_name}")
-        print(f"  - Vertices: {len(geom.vertices)}")
-        print(f"  - Faces: {len(geom.faces)}")
-
-        print(f"Geometry '{geom_name}':")
-        _handle_material_info(geom)
+    trimesh = _load_with_trimesh(path_to_obj, plot)
+    trisurf = trimesh_to_unstruct(trimesh)
+    return trisurf

--- a/subsurface/modules/visualization/to_pyvista.py
+++ b/subsurface/modules/visualization/to_pyvista.py
@@ -125,6 +125,14 @@ def to_pyvista_mesh(triangular_surface: TriSurf) -> "pv.PolyData":
     mesh.cell_data.update(triangular_surface.mesh.attributes_to_dict)
     mesh.point_data.update(triangular_surface.mesh.points_attributes)
 
+    # If UV coordinates exist in points_attributes, set them as texture coordinates
+    if 'u' in triangular_surface.mesh.points_attributes and 'v' in triangular_surface.mesh.points_attributes:
+        uv = np.column_stack((
+            triangular_surface.mesh.points_attributes['u'],
+            triangular_surface.mesh.points_attributes['v']
+        ))
+        mesh.active_texture_coordinates = uv
+
     if triangular_surface.has_texture_data:
         mesh.texture_map_to_plane(
             inplace=True,
@@ -134,7 +142,6 @@ def to_pyvista_mesh(triangular_surface: TriSurf) -> "pv.PolyData":
         )
 
         texture_data = np.asarray(triangular_surface.texture.values, dtype=np.float32)
-
         mesh._textures = {0: texture_data}
         mesh.active_scalars_name = None
 

--- a/subsurface/modules/visualization/to_pyvista.py
+++ b/subsurface/modules/visualization/to_pyvista.py
@@ -126,14 +126,17 @@ def to_pyvista_mesh(triangular_surface: TriSurf) -> "pv.PolyData":
     mesh.point_data.update(triangular_surface.mesh.points_attributes)
 
     # If UV coordinates exist in points_attributes, set them as texture coordinates
-    if 'u' in triangular_surface.mesh.points_attributes and 'v' in triangular_surface.mesh.points_attributes:
+    if triangular_surface.has_texture_data_with_uv:
         uv = np.column_stack((
             triangular_surface.mesh.points_attributes['u'],
             triangular_surface.mesh.points_attributes['v']
         ))
         mesh.active_texture_coordinates = uv
+        texture_data = np.asarray(triangular_surface.texture.values, dtype=np.float32)
+        mesh._textures = {0: texture_data}
+        mesh.active_scalars_name = None
 
-    if triangular_surface.has_texture_data:
+    elif triangular_surface.has_texture_data_without_uv:
         mesh.texture_map_to_plane(
             inplace=True,
             origin=triangular_surface.texture_origin,

--- a/subsurface/modules/visualization/to_pyvista.py
+++ b/subsurface/modules/visualization/to_pyvista.py
@@ -132,9 +132,10 @@ def to_pyvista_mesh(triangular_surface: TriSurf) -> "pv.PolyData":
             triangular_surface.mesh.points_attributes['v']
         ))
         mesh.active_texture_coordinates = uv
-        texture_data = np.asarray(triangular_surface.texture.values, dtype=np.float32)
-        mesh._textures = {0: texture_data}
-        mesh.active_scalars_name = None
+        if triangular_surface.texture is not None:
+            texture_data = np.asarray(triangular_surface.texture.values, dtype=np.float32)
+            mesh._textures = {0: texture_data}
+            mesh.active_scalars_name = None
 
     elif triangular_surface.has_texture_data_without_uv:
         mesh.texture_map_to_plane(

--- a/tests/test_io/test_meshes/test_glf.py
+++ b/tests/test_io/test_meshes/test_glf.py
@@ -4,7 +4,14 @@ import pytest
 import dotenv
 
 from subsurface import optional_requirements
+from subsurface.modules.reader.mesh.obj_reader import load_obj_with_trimesh
 from tests.conftest import RequirementsLevel
+
+import subsurface
+from subsurface.modules.visualization import to_pyvista_mesh, pv_plot
+
+from subsurface import optional_requirements, TriSurf
+from subsurface.modules.reader.mesh.obj_reader import load_obj_with_trimesh, trimesh_obj_to_unstruct
 
 dotenv.load_dotenv()
 
@@ -15,7 +22,7 @@ pytestmark = pytest.mark.read_mesh
     condition=(RequirementsLevel.MESH | RequirementsLevel.PLOT) not in RequirementsLevel.REQUIREMENT_LEVEL_TO_TEST(),
     reason="Need to set the READ_MESH variable to run this test"
 )
-def test_trimesh_read_glb():
+def test_trimesh_read_glb_complex():
     """
     Test loading a .glb (binary glTF) file with trimesh.
     If it's a scene, we iterate over submeshes; 
@@ -28,42 +35,28 @@ def test_trimesh_read_glb():
     assert os.path.exists(glb_path), f"GLB file does not exist: {glb_path}"
 
     # Trimesh can load GLB/GLTF natively
-    scene_or_mesh = trimesh.load(glb_path)
 
-    # Check if we got a scene or a single mesh
-    if isinstance(scene_or_mesh, trimesh.Scene):
-        print(f"Loaded a Scene with {len(scene_or_mesh.geometry)} geometry object(s).")
+    trimesh_obj = load_obj_with_trimesh(glb_path, plot=False)
+    ts: subsurface.TriSurf = trimesh_obj_to_unstruct(trimesh_obj)
+    s = to_pyvista_mesh(ts)
+    pv_plot([s], image_2d=False)
+    return
 
-        for geom_name, geom in scene_or_mesh.geometry.items():
-            print(f" Submesh: {geom_name}")
-            print(f"  - Vertices: {len(geom.vertices)}")
-            print(f"  - Faces: {len(geom.faces)}")
 
-            # Check if we have a material/visual
-            if geom.visual and hasattr(geom.visual, 'material'):
-                mat = geom.visual.material
-                print(f"  - Material: {mat}")
-            else:
-                print("  - No material data on this submesh.")
+def test_trimesh_read_glb():
+    """
+    Test loading a .glb (binary glTF) file with trimesh.
+    If it's a scene, we iterate over submeshes; 
+    if it's a single mesh, we inspect it directly.
+    """
 
-        # Optionally show the scene (only works in a GUI-friendly environment)
-        if PLOT := True:
-            scene_or_mesh.show()
+    glb_path = os.getenv("PATH_TO_GLB")
+    assert os.path.exists(glb_path), f"GLB file does not exist: {glb_path}"
 
-    else:
-        # A single Trimesh object
-        mesh = scene_or_mesh
-        print("Loaded a single Trimesh object.")
-        print(f" - Vertices: {len(mesh.vertices)}")
-        print(f" - Faces: {len(mesh.faces)}")
+    # Trimesh can load GLB/GLTF natively
 
-        # Check material
-        if mesh.visual and hasattr(mesh.visual, 'material'):
-            mat = mesh.visual.material
-            print(f"Material: {mat}")
-        else:
-            print("No material data on this mesh.")
-
-        # Optionally show the scene (only works in a GUI-friendly environment)
-        if PLOT := True:
-            scene_or_mesh.show()
+    trimesh_obj = load_obj_with_trimesh(glb_path, plot=False)
+    ts: subsurface.TriSurf = trimesh_obj_to_unstruct(trimesh_obj)
+    s = to_pyvista_mesh(ts)
+    pv_plot([s], image_2d=True)
+    return 

--- a/tests/test_io/test_meshes/test_glf.py
+++ b/tests/test_io/test_meshes/test_glf.py
@@ -4,6 +4,7 @@ import pytest
 import dotenv
 
 from subsurface import optional_requirements
+from subsurface.modules.reader.mesh.glb_reader import load_glb_with_trimesh
 from subsurface.modules.reader.mesh.obj_reader import load_obj_with_trimesh
 from tests.conftest import RequirementsLevel
 
@@ -11,7 +12,7 @@ import subsurface
 from subsurface.modules.visualization import to_pyvista_mesh, pv_plot
 
 from subsurface import optional_requirements, TriSurf
-from subsurface.modules.reader.mesh.obj_reader import load_obj_with_trimesh, trimesh_obj_to_unstruct
+from subsurface.modules.reader.mesh.obj_reader import load_obj_with_trimesh, trimesh_to_unstruct
 
 dotenv.load_dotenv()
 
@@ -36,10 +37,9 @@ def test_trimesh_read_glb_complex():
 
     # Trimesh can load GLB/GLTF natively
 
-    trimesh_obj = load_obj_with_trimesh(glb_path, plot=False)
-    ts: subsurface.TriSurf = trimesh_obj_to_unstruct(trimesh_obj)
+    ts: subsurface.TriSurf = load_glb_with_trimesh(glb_path)
     s = to_pyvista_mesh(ts)
-    pv_plot([s], image_2d=False)
+    pv_plot([s], image_2d=True)
     return
 
 
@@ -55,8 +55,7 @@ def test_trimesh_read_glb():
 
     # Trimesh can load GLB/GLTF natively
 
-    trimesh_obj = load_obj_with_trimesh(glb_path, plot=False)
-    ts: subsurface.TriSurf = trimesh_obj_to_unstruct(trimesh_obj)
+    ts = load_glb_with_trimesh(glb_path, plot=False)
     s = to_pyvista_mesh(ts)
     pv_plot([s], image_2d=True)
     return 

--- a/tests/test_io/test_meshes/test_read_obj.py
+++ b/tests/test_io/test_meshes/test_read_obj.py
@@ -6,8 +6,8 @@ import dotenv
 import subsurface
 from subsurface.modules.visualization import to_pyvista_mesh, pv_plot
 
-from subsurface import optional_requirements, TriSurf
-from subsurface.modules.reader.mesh.obj_reader import load_obj_with_trimesh, trimesh_obj_to_unstruct
+from subsurface import optional_requirements
+from subsurface.modules.reader.mesh._trimesh_reader import trimesh_to_unstruct, _load_with_trimesh
 from tests.conftest import RequirementsLevel
 
 dotenv.load_dotenv()
@@ -17,19 +17,19 @@ path_to_mtl = os.getenv("PATH_TO_MTL")
 path_to_obj_no_material = os.getenv("PATH_TO_OBJ_GALLERIES_I")
 
 pytestmark = pytest.mark.read_mesh
-
-
-@pytest.mark.skipif(
-    condition=(RequirementsLevel.MESH | RequirementsLevel.PLOT) not in RequirementsLevel.REQUIREMENT_LEVEL_TO_TEST(),
-    reason="Need to set the READ_MESH variable to run this test"
+pytestmark = pytest.mark.skipif(
+    condition=(RequirementsLevel.READ_MESH) not in RequirementsLevel.REQUIREMENT_LEVEL_TO_TEST(),
+    reason="Need to set READ_MESH"
 )
+
+
 def test_read_obj_mesh_no_materials():
     pv = optional_requirements.require_pyvista()
     reader: pv.OBJReader = pv.get_reader(path_to_obj_no_material)
     mesh = reader.read()
     # Access texture coordinates if present
 
-    if plot := True:
+    if plot := False:
         mesh.plot()
 
 
@@ -39,51 +39,51 @@ def test_trimesh_load_obj_with_mtl_submeshes_heavy():
 
     assert os.path.exists(path_to_obj), f"OBJ not found: {path_to_obj}"
     assert os.path.exists(path_to_mtl), f"MTL not found: {path_to_mtl}"
-    load_obj_with_trimesh(path_to_obj, plot=True)
+    _load_with_trimesh(path_to_obj, plot=False)
 
 
 def test_trimesh_load_obj_with_mtl_submeshes_II():
     # Replace these with the actual paths in your environment
     path_to_obj = os.getenv("PATH_TO_OBJ_MULTIMATERIAL_II")
-    load_obj_with_trimesh(path_to_obj, plot=True)
+    _load_with_trimesh(path_to_obj, plot=False)
 
 
 def test_trimesh_load_obj_with_jpg_texture():
     path_to_obj = os.getenv("TERRA_PATH_DEVOPS") + "/meshes/OBJ/Portugal outcrop decimated/textured_output.obj"
-    load_obj_with_trimesh(path_to_obj)
+    _load_with_trimesh(path_to_obj)
 
 
 def test_trimesh_load_obj_with_face_I():
     path_to_obj = os.getenv("PATH_TO_OBJ_FACE_I")
-    load_obj_with_trimesh(path_to_obj, plot=True)
+    _load_with_trimesh(path_to_obj, plot=False)
 
 
 def test_trimesh_load_obj_with_face_II():
     path_to_obj = os.getenv("PATH_TO_OBJ_FACE_II")
-    load_obj_with_trimesh(path_to_obj, plot=True)
+    _load_with_trimesh(path_to_obj, plot=False)
 
 
 def test_trimesh_load_obj_boxes():
     path_to_obj = os.getenv("PATH_TO_OBJ_SCANS")
-    load_obj_with_trimesh(path_to_obj)
+    _load_with_trimesh(path_to_obj)
 
 
 def test_trimesh_load_obj_with_texture_II():
     """Penguin, material exist but png is not loading correctly"""
     path_to_obj = os.getenv("TERRA_PATH_DEVOPS") + "/meshes/OBJ/TexturedMesh/PenguinBaseMesh.obj"
-    load_obj_with_trimesh(
+    _load_with_trimesh(
         path_to_obj=path_to_obj,
-        plot=True
+        plot=False
     )
 
 
 def test_trimesh_one_element_no_texture_to_unstruct():
     path_to_obj = os.getenv("TERRA_PATH_DEVOPS") + "/meshes/OBJ/TexturedMesh/PenguinBaseMesh.obj"
-    trimesh_obj = load_obj_with_trimesh(
+    trimesh_obj = _load_with_trimesh(
         path_to_obj=path_to_obj,
         plot=False
     )
-    ts = trimesh_obj_to_unstruct(trimesh_obj)
+    ts = trimesh_to_unstruct(trimesh_obj)
 
     s = to_pyvista_mesh(ts)
     pv_plot([s], image_2d=True)
@@ -91,34 +91,34 @@ def test_trimesh_one_element_no_texture_to_unstruct():
 
 def test_trimesh_three_element_no_texture_to_unstruct():
     path_to_obj = os.getenv("PATH_TO_OBJ_MULTIMATERIAL_II")
-    trimesh_obj = load_obj_with_trimesh(path_to_obj)
+    trimesh_obj = _load_with_trimesh(path_to_obj)
 
-    ts = trimesh_obj_to_unstruct(trimesh_obj)
+    ts = trimesh_to_unstruct(trimesh_obj)
 
     s = to_pyvista_mesh(ts)
-    pv_plot([s], image_2d=False)
+    pv_plot([s], image_2d=True)
 
 
 def test_trimesh_ONE_element_texture_to_unstruct():
-    trimesh_obj = load_obj_with_trimesh(
+    trimesh_obj = _load_with_trimesh(
         path_to_obj=(os.getenv("PATH_TO_OBJ_FACE_II")),
         plot=False
     )
 
-    ts: subsurface.TriSurf = trimesh_obj_to_unstruct(trimesh_obj)
+    ts: subsurface.TriSurf = trimesh_to_unstruct(trimesh_obj)
 
     s = to_pyvista_mesh(ts)
     pv_plot([s], image_2d=True)
-   
+
 
 def test_trimesh_three_element_texture_to_unstruct():
     """This prints only the uv since we do not want to read
     multiple images as structured objects
     """
     path_to_obj = os.getenv("PATH_TO_OBJ_SCANS")
-    trimesh_obj = load_obj_with_trimesh(path_to_obj)
+    trimesh_obj = _load_with_trimesh(path_to_obj)
 
-    ts = trimesh_obj_to_unstruct(trimesh_obj)
+    ts = trimesh_to_unstruct(trimesh_obj)
 
     s = to_pyvista_mesh(ts)
-    pv_plot([s], image_2d=False)
+    pv_plot([s], image_2d=True)

--- a/tests/test_io/test_meshes/test_read_obj.py
+++ b/tests/test_io/test_meshes/test_read_obj.py
@@ -4,6 +4,7 @@ import pytest
 import dotenv
 
 from subsurface import optional_requirements
+from subsurface.modules.reader.mesh.obj_reader import load_obj_with_trimesh
 from tests.conftest import RequirementsLevel
 
 dotenv.load_dotenv()
@@ -29,97 +30,19 @@ def test_read_obj_mesh_no_materials():
         mesh.plot()
 
 
-def test_trimesh_load_obj_with_mtl_submeshes():
-    # TODO: [ ] Use smaller example
+def test_trimesh_load_obj_with_mtl_submeshes_heavy():
+    """This is a heavy test"""
     # Replace these with the actual paths in your environment
 
     assert os.path.exists(path_to_obj), f"OBJ not found: {path_to_obj}"
     assert os.path.exists(path_to_mtl), f"MTL not found: {path_to_mtl}"
-    import trimesh
-
-    # Load the OBJ with Trimesh
-    # - By default, trimesh.load will return a Scene if the OBJ has multiple parts/materials
-    # - If it's a single mesh, it returns a Trimesh
-    scene_or_mesh = trimesh.load(path_to_obj)
-
-    if isinstance(scene_or_mesh, trimesh.Scene):
-        print("Loaded a Scene with multiple geometries.")
-
-        # Each geometry in the scene can have its own visual/material
-        geometries = scene_or_mesh.geometry
-        assert len(geometries) > 0, "No geometries found in the scene."
-
-        for geom_name, geom in geometries.items():
-            # 'geom' should be a Trimesh object
-            if geom.visual and hasattr(geom.visual, 'material'):
-                material = geom.visual.material
-                print(f"Geometry '{geom_name}' has material: {material}")
-            else:
-                print(f"Geometry '{geom_name}' has no material attribute.")
-
-        # Show the scene (opens an interactive viewer if possible):
-        # If you're running tests in a headless environment, comment this out
-        if PLOT := False:
-            scene_or_mesh.show()
-
-    else:
-        # Single Trimesh object
-        print("Loaded a single Trimesh.")
-
-        if scene_or_mesh.visual and hasattr(scene_or_mesh.visual, 'material'):
-            material = scene_or_mesh.visual.material
-            print("Trimesh material:", material)
-        else:
-            print("No material found on this single-mesh object.")
-
-        # Show the mesh (interactive viewer)
-        if PLOT := False:
-            scene_or_mesh.show()
+    load_obj_with_trimesh(path_to_obj, plot=True)
 
 
 def test_trimesh_load_obj_with_mtl_submeshes_II():
     # Replace these with the actual paths in your environment
     path_to_obj = os.getenv("PATH_TO_OBJ_MULTIMATERIAL_II")
-    import trimesh
-
-    # Load the OBJ with Trimesh
-    # - By default, trimesh.load will return a Scene if the OBJ has multiple parts/materials
-    # - If it's a single mesh, it returns a Trimesh
-    scene_or_mesh = trimesh.load(path_to_obj)
-
-    if isinstance(scene_or_mesh, trimesh.Scene):
-        print("Loaded a Scene with multiple geometries.")
-
-        # Each geometry in the scene can have its own visual/material
-        geometries = scene_or_mesh.geometry
-        assert len(geometries) > 0, "No geometries found in the scene."
-
-        for geom_name, geom in geometries.items():
-            # 'geom' should be a Trimesh object
-            if geom.visual and hasattr(geom.visual, 'material'):
-                material = geom.visual.material
-                print(f"Geometry '{geom_name}' has material: {material}")
-            else:
-                print(f"Geometry '{geom_name}' has no material attribute.")
-
-        # Show the scene (opens an interactive viewer if possible):
-        # If you're running tests in a headless environment, comment this out
-        if PLOT := True:
-            scene_or_mesh.show()
-
-    else:
-        # Single Trimesh object
-        print("Loaded a single Trimesh.")
-
-        if scene_or_mesh.visual and hasattr(scene_or_mesh.visual, 'material'):
-            material = scene_or_mesh.visual.material
-            print("Trimesh material:", material)
-        else:
-            print("No material found on this single-mesh object.")
-
-        # Show the mesh (interactive viewer)
-        if PLOT := False:
-            scene_or_mesh.show()
+    load_obj_with_trimesh(path_to_obj, plot=True)
 
 
 def test_trimesh_load_obj_with_jpg_texture():
@@ -144,49 +67,8 @@ def test_trimesh_load_obj_boxes():
 
 def test_trimesh_load_obj_with_texture_II():
     """Penguin, material exist but png is not loading correctly"""
-    raise NotImplementedError("We need to add the option to point to at least one texture directly")
     path_to_obj = os.getenv("TERRA_PATH_DEVOPS") + "/meshes/OBJ/TexturedMesh/PenguinBaseMesh.obj"
-    load_obj_with_trimesh(path_to_obj)
-
-
-def load_obj_with_trimesh(path_to_obj):
-    import trimesh
-
-    # Load the OBJ with Trimesh
-    # - By default, trimesh.load will return a Scene if the OBJ has multiple parts/materials
-    # - If it's a single mesh, it returns a Trimesh
-    scene_or_mesh = trimesh.load(path_to_obj)
-
-    if isinstance(scene_or_mesh, trimesh.Scene):
-        print("Loaded a Scene with multiple geometries.")
-
-        # Each geometry in the scene can have its own visual/material
-        geometries = scene_or_mesh.geometry
-        assert len(geometries) > 0, "No geometries found in the scene."
-
-        for geom_name, geom in geometries.items():
-            # 'geom' should be a Trimesh object
-            if geom.visual and hasattr(geom.visual, 'material'):
-                material = geom.visual.material
-                print(f"Geometry '{geom_name}' has material: {material}")
-            else:
-                print(f"Geometry '{geom_name}' has no material attribute.")
-
-        # Show the scene (opens an interactive viewer if possible):
-        # If you're running tests in a headless environment, comment this out
-        if PLOT := True:
-            scene_or_mesh.show()
-
-    else:
-        # Single Trimesh object
-        print("Loaded a single Trimesh.")
-
-        if scene_or_mesh.visual and hasattr(scene_or_mesh.visual, 'material'):
-            material = scene_or_mesh.visual.material
-            print("Trimesh material:", material)
-        else:
-            print("No material found on this single-mesh object.")
-
-        # Show the mesh (interactive viewer)
-        if PLOT := True:
-            scene_or_mesh.show()
+    load_obj_with_trimesh(
+        path_to_obj=path_to_obj,
+        plot=True
+    )

--- a/tests/test_io/test_meshes/test_read_obj.py
+++ b/tests/test_io/test_meshes/test_read_obj.py
@@ -16,7 +16,6 @@ path_to_obj = os.getenv("PATH_TO_OBJ")
 path_to_mtl = os.getenv("PATH_TO_MTL")
 path_to_obj_no_material = os.getenv("PATH_TO_OBJ_GALLERIES_I")
 
-pytestmark = pytest.mark.read_mesh
 pytestmark = pytest.mark.skipif(
     condition=(RequirementsLevel.READ_MESH) not in RequirementsLevel.REQUIREMENT_LEVEL_TO_TEST(),
     reason="Need to set READ_MESH"

--- a/tests/test_io/test_meshes/test_read_obj.py
+++ b/tests/test_io/test_meshes/test_read_obj.py
@@ -112,7 +112,9 @@ def test_trimesh_ONE_element_texture_to_unstruct():
    
 
 def test_trimesh_three_element_texture_to_unstruct():
-    # TODO: Add texture
+    """This prints only the uv since we do not want to read
+    multiple images as structured objects
+    """
     path_to_obj = os.getenv("PATH_TO_OBJ_SCANS")
     trimesh_obj = load_obj_with_trimesh(path_to_obj)
 

--- a/tests/test_io/test_meshes/test_read_obj.py
+++ b/tests/test_io/test_meshes/test_read_obj.py
@@ -2,9 +2,10 @@
 
 import pytest
 import dotenv
+from subsurface.modules.visualization import to_pyvista_mesh, pv_plot
 
-from subsurface import optional_requirements
-from subsurface.modules.reader.mesh.obj_reader import load_obj_with_trimesh
+from subsurface import optional_requirements, TriSurf
+from subsurface.modules.reader.mesh.obj_reader import load_obj_with_trimesh, trimesh_obj_to_unstruct
 from tests.conftest import RequirementsLevel
 
 dotenv.load_dotenv()
@@ -52,12 +53,12 @@ def test_trimesh_load_obj_with_jpg_texture():
 
 def test_trimesh_load_obj_with_face_I():
     path_to_obj = os.getenv("PATH_TO_OBJ_FACE_I")
-    load_obj_with_trimesh(path_to_obj)
+    load_obj_with_trimesh(path_to_obj, plot=True)
 
 
 def test_trimesh_load_obj_with_face_II():
     path_to_obj = os.getenv("PATH_TO_OBJ_FACE_II")
-    load_obj_with_trimesh(path_to_obj)
+    load_obj_with_trimesh(path_to_obj, plot=True)
 
 
 def test_trimesh_load_obj_boxes():
@@ -72,3 +73,51 @@ def test_trimesh_load_obj_with_texture_II():
         path_to_obj=path_to_obj,
         plot=True
     )
+
+
+def test_trimesh_one_element_no_texture_to_unstruct():
+    path_to_obj = os.getenv("TERRA_PATH_DEVOPS") + "/meshes/OBJ/TexturedMesh/PenguinBaseMesh.obj"
+    trimesh_obj = load_obj_with_trimesh(
+        path_to_obj=path_to_obj,
+        plot=False
+    )
+    unstruct = trimesh_obj_to_unstruct(trimesh_obj)
+
+    ts = TriSurf(mesh=unstruct)
+    s = to_pyvista_mesh(ts)
+    pv_plot([s], image_2d=True)
+
+
+def test_trimesh_three_element_no_texture_to_unstruct():
+    path_to_obj = os.getenv("PATH_TO_OBJ_MULTIMATERIAL_II")
+    trimesh_obj = load_obj_with_trimesh(path_to_obj)
+
+    unstruct = trimesh_obj_to_unstruct(trimesh_obj)
+
+    ts = TriSurf(mesh=unstruct)
+    s = to_pyvista_mesh(ts)
+    pv_plot([s], image_2d=False)
+
+
+def test_trimesh_ONE_element_texture_to_unstruct():
+    # TODO: Add texture
+    path_to_obj = os.getenv("PATH_TO_OBJ_FACE_II")
+    trimesh_obj = load_obj_with_trimesh(path_to_obj)
+
+    unstruct = trimesh_obj_to_unstruct(trimesh_obj)
+
+    ts = TriSurf(mesh=unstruct)
+    s = to_pyvista_mesh(ts)
+    pv_plot([s], image_2d=False)
+   
+
+def test_trimesh_three_element_texture_to_unstruct():
+    # TODO: Add texture
+    path_to_obj = os.getenv("PATH_TO_OBJ_SCANS")
+    trimesh_obj = load_obj_with_trimesh(path_to_obj)
+
+    unstruct = trimesh_obj_to_unstruct(trimesh_obj)
+
+    ts = TriSurf(mesh=unstruct)
+    s = to_pyvista_mesh(ts)
+    pv_plot([s], image_2d=False)

--- a/tests/test_io/test_meshes/test_read_obj.py
+++ b/tests/test_io/test_meshes/test_read_obj.py
@@ -116,8 +116,7 @@ def test_trimesh_three_element_texture_to_unstruct():
     path_to_obj = os.getenv("PATH_TO_OBJ_SCANS")
     trimesh_obj = load_obj_with_trimesh(path_to_obj)
 
-    unstruct = trimesh_obj_to_unstruct(trimesh_obj)
+    ts = trimesh_obj_to_unstruct(trimesh_obj)
 
-    ts = TriSurf(mesh=unstruct)
     s = to_pyvista_mesh(ts)
     pv_plot([s], image_2d=False)

--- a/tests/test_io/test_meshes/test_read_obj.py
+++ b/tests/test_io/test_meshes/test_read_obj.py
@@ -2,6 +2,8 @@
 
 import pytest
 import dotenv
+
+import subsurface
 from subsurface.modules.visualization import to_pyvista_mesh, pv_plot
 
 from subsurface import optional_requirements, TriSurf
@@ -81,9 +83,8 @@ def test_trimesh_one_element_no_texture_to_unstruct():
         path_to_obj=path_to_obj,
         plot=False
     )
-    unstruct = trimesh_obj_to_unstruct(trimesh_obj)
+    ts = trimesh_obj_to_unstruct(trimesh_obj)
 
-    ts = TriSurf(mesh=unstruct)
     s = to_pyvista_mesh(ts)
     pv_plot([s], image_2d=True)
 
@@ -92,23 +93,22 @@ def test_trimesh_three_element_no_texture_to_unstruct():
     path_to_obj = os.getenv("PATH_TO_OBJ_MULTIMATERIAL_II")
     trimesh_obj = load_obj_with_trimesh(path_to_obj)
 
-    unstruct = trimesh_obj_to_unstruct(trimesh_obj)
+    ts = trimesh_obj_to_unstruct(trimesh_obj)
 
-    ts = TriSurf(mesh=unstruct)
     s = to_pyvista_mesh(ts)
     pv_plot([s], image_2d=False)
 
 
 def test_trimesh_ONE_element_texture_to_unstruct():
-    # TODO: Add texture
-    path_to_obj = os.getenv("PATH_TO_OBJ_FACE_II")
-    trimesh_obj = load_obj_with_trimesh(path_to_obj)
+    trimesh_obj = load_obj_with_trimesh(
+        path_to_obj=(os.getenv("PATH_TO_OBJ_FACE_II")),
+        plot=False
+    )
 
-    unstruct = trimesh_obj_to_unstruct(trimesh_obj)
+    ts: subsurface.TriSurf = trimesh_obj_to_unstruct(trimesh_obj)
 
-    ts = TriSurf(mesh=unstruct)
     s = to_pyvista_mesh(ts)
-    pv_plot([s], image_2d=False)
+    pv_plot([s], image_2d=True)
    
 
 def test_trimesh_three_element_texture_to_unstruct():

--- a/tests/test_io/test_meshes/test_read_obj.py
+++ b/tests/test_io/test_meshes/test_read_obj.py
@@ -8,7 +8,6 @@ from subsurface.modules.visualization import to_pyvista_mesh, pv_plot
 
 from subsurface import optional_requirements
 from subsurface.modules.reader.mesh._trimesh_reader import trimesh_to_unstruct, _load_with_trimesh
-from tests.conftest import RequirementsLevel
 
 dotenv.load_dotenv()
 
@@ -16,10 +15,7 @@ path_to_obj = os.getenv("PATH_TO_OBJ")
 path_to_mtl = os.getenv("PATH_TO_MTL")
 path_to_obj_no_material = os.getenv("PATH_TO_OBJ_GALLERIES_I")
 
-pytestmark = pytest.mark.skipif(
-    condition=(RequirementsLevel.READ_MESH) not in RequirementsLevel.REQUIREMENT_LEVEL_TO_TEST(),
-    reason="Need to set READ_MESH"
-)
+pytestmark = pytest.mark.read_mesh
 
 
 def test_read_obj_mesh_no_materials():

--- a/tests/test_io/test_meshes/test_read_profiles.py
+++ b/tests/test_io/test_meshes/test_read_profiles.py
@@ -205,7 +205,7 @@ class TestSeismicProfiles:
 
         pv_plot(
             meshes=[to_pyvista_mesh(ts)],
-            image_2d=False
+            image_2d=True
         )
 
     def test_seismic_profile(self):
@@ -252,7 +252,7 @@ class TestSeismicProfiles:
 
         pv_plot(
             meshes=[to_pyvista_mesh(ts)],
-            image_2d=False
+            image_2d=True
         )
 
 

--- a/tests/test_io/test_meshes/test_segy_reader.py
+++ b/tests/test_io/test_meshes/test_segy_reader.py
@@ -212,38 +212,39 @@ def test_segy_3d_segy__volume_segsak_II() -> None:
 
     # Step II
 
-    # Ensure the order is (samples, iline, xline)
-    # Some xarray objects might already be in that order
-    data_da = V3D.data.transpose("samples", "iline", "xline")
+    if PLOT:=False:
+        # Ensure the order is (samples, iline, xline)
+        # Some xarray objects might already be in that order
+        data_da = V3D.data.transpose("samples", "iline", "xline")
 
-    # Convert to a NumPy array
-    data_3d = data_da.values  # shape: (nz, ny, nx)
-    nz, ny, nx = data_3d.shape
-    print("3D Data Shape:", data_3d.shape)
+        # Convert to a NumPy array
+        data_3d = data_da.values  # shape: (nz, ny, nx)
+        nz, ny, nx = data_3d.shape
+        print("3D Data Shape:", data_3d.shape)
 
-    import pyvista as pv
+        import pyvista as pv
 
-    # Spacing in each dimension (index spacing = 1 by default, or define actual spacing if known)
-    dx = 1.0  # spacing along xline
-    dy = 1.0  # spacing along iline
-    dz = 1.0  # spacing along samples (e.g., 2 ms, or convert to depth if you have a velocity model)
+        # Spacing in each dimension (index spacing = 1 by default, or define actual spacing if known)
+        dx = 1.0  # spacing along xline
+        dy = 1.0  # spacing along iline
+        dz = 1.0  # spacing along samples (e.g., 2 ms, or convert to depth if you have a velocity model)
 
-    # Origin (0,0,0) or shift as needed
-    origin = (0, 0, 0)
+        # Origin (0,0,0) or shift as needed
+        origin = (0, 0, 0)
 
-    # Create the UniformGrid
-    grid = pv.UniformGrid()
-    grid.origin = origin  # bottom-left of the dataset
-    grid.spacing = (dx, dy, dz)  # distance between points along each axis
-    grid.dimensions = (nx, ny, nz)  # note the order: (x, y, z)
-    # Flatten the data in x-fastest order (Fortran order) if needed
-    grid.point_data["Amplitude"] = data_3d.ravel(order="F")
+        # Create the UniformGrid
+        grid = pv.UniformGrid()
+        grid.origin = origin  # bottom-left of the dataset
+        grid.spacing = (dx, dy, dz)  # distance between points along each axis
+        grid.dimensions = (nx, ny, nz)  # note the order: (x, y, z)
+        # Flatten the data in x-fastest order (Fortran order) if needed
+        grid.point_data["Amplitude"] = data_3d.ravel(order="F")
 
-    # Volume Rendering
-    plotter = pv.Plotter()
-    plotter.add_volume(grid, cmap="seismic", opacity="sigmoid")
-    plotter.show_grid()
-    plotter.show()
+        # Volume Rendering
+        plotter = pv.Plotter()
+        plotter.add_volume(grid, cmap="seismic", opacity="sigmoid")
+        plotter.show_grid()
+        plotter.show()
 
 
 def test_segy_3d_segy_segsak_III() -> None:


### PR DESCRIPTION
[ENH] Moving code to import obj

Add trimesh to unstructured conversion and UV support

Introduced `trimesh_obj_to_unstruct` to convert Trimesh objects/scenes to UnstructuredData. Added handling of UV coordinates for texture mapping and updated `to_pyvista_mesh` to set active texture coordinates when present. Enhanced tests to include conversion functions and visualization.

Refactor texture handling across OBJ mesh pipeline

Update texture data handling for OBJ mesh reading, improving compatibility with both UV-coordinate-based and non-UV-coordinate-based textures. Adjust related tests and visualization logic to align with the updated approach, enhancing functionality and maintainability.

Deal with multielement OBJ

Converting materials to subsurface objects to some extent

[CLN] Refactor code to extract common code between obj and glb