### PR TITLE
Add test for VTK file creation from NumPy data

### DIFF
--- a/tests/test_io/test_volumes/test_import_volume_vtk.py
+++ b/tests/test_io/test_volumes/test_import_volume_vtk.py
@@ -68,25 +68,65 @@ def test_vtk_file_to_structured_data() -> subsurface.StructuredData:
     return struct
 
 
+def test_vtk_from_numpy():
+
+    import numpy as np
+    import pyvista as pv
+
+    ni, nj, nk = 4, 5, 6
+    si, sj, sk = 20, 10, 1
+
+    xcorn = np.arange(0, (ni + 1) * si, si)
+    xcorn = np.repeat(xcorn, 2)
+    xcorn = xcorn[1:-1]
+    xcorn = np.tile(xcorn, 4 * nj * nk)
+
+    ycorn = np.arange(0, (nj + 1) * sj, sj)
+    ycorn = np.repeat(ycorn, 2)
+    ycorn = ycorn[1:-1]
+    ycorn = np.tile(ycorn, (2 * ni, 2 * nk))
+    ycorn = np.transpose(ycorn)
+    ycorn = ycorn.flatten()
+
+    zcorn = np.arange(0, (nk + 1) * sk, sk)
+    zcorn = np.repeat(zcorn, 2)
+    zcorn = zcorn[1:-1]
+    zcorn = np.repeat(zcorn, (4 * ni * nj))
+
+    corners = np.stack((xcorn, ycorn, zcorn))
+    corners = corners.transpose()
+
+    dims = np.asarray((ni, nj, nk)) + 1
+    print("Dims: ", dims)
+    print("Corners: ", corners.shape)
+    print("Corners: ", corners)
+    
+    grid = pv.ExplicitStructuredGrid(dims, corners)
+    grid = grid.compute_connectivity()
+
+    # * Attributes
+    grid.cell_data['Cell Number'] = range(grid.n_cells)
+
+    # Temp file save
+    with NamedTemporaryFile(suffix='.vtk', delete=False) as temp_file:
+        grid.save(temp_file.name)
+        print(f"VTK file saved to: {temp_file.name}")
+    grid.plot(show_edges=True)
+    
+    
+
 def test_vtk_file_to_binary():
     struct: subsurface.StructuredData = test_vtk_file_to_structured_data()
     print(struct.bounds)
-    
+
     struct.active_data_array_name = "Cell Number"
     binary_cell_number = struct.to_binary()
 
-    
     struct.active_data_array_name = "Random"
     binary_random = struct.to_binary()
 
-    if WRITE_TO_DISK:=False:
+    if WRITE_TO_DISK := False:
         new_file = open("test_volume_Cell Number.le", "wb")
         new_file.write(binary_cell_number)
         new_file = open("test_volume_Random.le", "wb")
         new_file.write(binary_random)
-
-    
-    
-    
-    
-    


### PR DESCRIPTION
Introduced a new test function `test_vtk_from_numpy` to generate and save VTK files using `pyvista.ExplicitStructuredGrid` with NumPy-generated corner data. This enhances test coverage for volume import workflows and ensures proper grid file creation.