### PR TITLE
[ENH] Add OBJ and GLTF stream to trisurf conversion | GEN-11489 | GEN-11777

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ Python installation file.
 import os
 import sys
 from os import path
-from setuptools import setup_test_environment, find_packages
+from setuptools import setup, find_packages
 
 if not sys.version_info[:2] >= (3, 8):
     sys.exit(f"subsurface is only meant for Python 3.8 and up.\n"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ Python installation file.
 import os
 import sys
 from os import path
-from setuptools import setup, find_packages
+from setuptools import setup_test_environment, find_packages
 
 if not sys.version_info[:2] >= (3, 8):
     sys.exit(f"subsurface is only meant for Python 3.8 and up.\n"

--- a/subsurface/api/__init__.py
+++ b/subsurface/api/__init__.py
@@ -7,4 +7,5 @@ from .interfaces.stream import (
     CSV_volume_stream_to_struct,
     VTK_stream_to_struct,  
     MX_stream_to_unstruc,
+    OBJ_stream_to_trisurf
 )

--- a/subsurface/api/__init__.py
+++ b/subsurface/api/__init__.py
@@ -7,5 +7,6 @@ from .interfaces.stream import (
     CSV_volume_stream_to_struct,
     VTK_stream_to_struct,  
     MX_stream_to_unstruc,
-    OBJ_stream_to_trisurf
+    OBJ_stream_to_trisurf,
+    GLTF_stream_to_trisurf
 )

--- a/subsurface/api/interfaces/stream.py
+++ b/subsurface/api/interfaces/stream.py
@@ -11,6 +11,7 @@ from ...core.geological_formats import BoreholeSet
 from ...core.structs.base_structures import UnstructuredData, StructuredData
 
 from ...modules import reader
+from ...modules.reader.mesh._trimesh_reader import TriMeshTransformations
 from ...modules.reader.volume.read_volume import read_volumetric_mesh_to_subsurface, read_VTK_structured_grid
 from ...modules.reader.mesh.surfaces_api import read_2d_mesh_to_unstruct
 from ...modules.reader.volume.volume_utils import interpolate_unstructured_data_to_structured_data
@@ -41,17 +42,19 @@ def MX_stream_to_unstruc(stream: TextIO) -> list[UnstructuredData]:
     return list_unstruct
 
 
-def OBJ_stream_to_trisurf(obj_stream: TextIO, mtl_stream: list[TextIO], texture_stream: list[io.BytesIO]) -> TriSurf:
+def OBJ_stream_to_trisurf(obj_stream: TextIO, mtl_stream: list[TextIO],
+                          texture_stream: list[io.BytesIO], coordinate_system: TriMeshTransformations) -> TriSurf:
     tri_mesh: TriSurf = reader.load_obj_with_trimesh_from_binary(
         obj_stream=obj_stream,
         mtl_stream=mtl_stream,
-        texture_stream=texture_stream
+        texture_stream=texture_stream,
+        coord_system=coordinate_system
     )
     return tri_mesh
 
 
-def GLTF_stream_to_trisurf(gltf_stream: io.BytesIO) -> TriSurf:
-    tri_mesh: TriSurf = reader.load_gltf_with_trimesh(gltf_stream)
+def GLTF_stream_to_trisurf(gltf_stream: io.BytesIO, coordinate_system: TriMeshTransformations) -> TriSurf:
+    tri_mesh: TriSurf = reader.load_gltf_with_trimesh(gltf_stream, coordinate_system)
     return tri_mesh
 
 def VTK_stream_to_struct(stream: BytesIO, attribute_name: str) -> list[StructuredData]:

--- a/subsurface/api/interfaces/stream.py
+++ b/subsurface/api/interfaces/stream.py
@@ -2,8 +2,8 @@ from io import BytesIO
 from typing import TextIO
 
 import pandas
-from subsurface.modules.reader.volume.volume_utils import interpolate_unstructured_data_to_structured_data
 
+from ...core.structs import TriSurf
 from ...core.reader_helpers.reader_unstruct import ReaderUnstructuredHelper
 from ...core.reader_helpers.readers_data import GenericReaderFilesHelper
 from ...core.geological_formats import BoreholeSet
@@ -12,6 +12,7 @@ from ...core.structs.base_structures import UnstructuredData, StructuredData
 from ...modules import reader
 from ...modules.reader.volume.read_volume import read_volumetric_mesh_to_subsurface, read_VTK_structured_grid
 from ...modules.reader.mesh.surfaces_api import read_2d_mesh_to_unstruct
+from ...modules.reader.volume.volume_utils import interpolate_unstructured_data_to_structured_data
 
 from ..reader.read_wells import read_wells
 
@@ -37,6 +38,12 @@ def OMF_stream_to_unstruc(stream: BytesIO) -> list[UnstructuredData]:
 def MX_stream_to_unstruc(stream: TextIO) -> list[UnstructuredData]:
     list_unstruct: list[UnstructuredData] = [reader.mx_to_unstruc_from_binary(stream)]
     return list_unstruct
+
+
+def OBJ_stream_to_trisurf(stream: BytesIO) -> TriSurf:
+    tri_mesh: TriSurf = reader.load_obj_with_trimesh_from_binary(stream)
+    breakpoint()
+    raise NotImplementedError
 
 
 def VTK_stream_to_struct(stream: BytesIO, attribute_name: str) -> list[StructuredData]:

--- a/subsurface/api/interfaces/stream.py
+++ b/subsurface/api/interfaces/stream.py
@@ -50,6 +50,10 @@ def OBJ_stream_to_trisurf(obj_stream: TextIO, mtl_stream: list[TextIO], texture_
     return tri_mesh
 
 
+def GLTF_stream_to_trisurf(gltf_stream: io.BytesIO) -> TriSurf:
+    tri_mesh: TriSurf = reader.load_gltf_with_trimesh(gltf_stream)
+    return tri_mesh
+
 def VTK_stream_to_struct(stream: BytesIO, attribute_name: str) -> list[StructuredData]:
     struct = read_VTK_structured_grid(stream, attribute_name)
     return [struct]

--- a/subsurface/api/interfaces/stream.py
+++ b/subsurface/api/interfaces/stream.py
@@ -1,3 +1,4 @@
+import io
 from io import BytesIO
 from typing import TextIO
 
@@ -40,10 +41,13 @@ def MX_stream_to_unstruc(stream: TextIO) -> list[UnstructuredData]:
     return list_unstruct
 
 
-def OBJ_stream_to_trisurf(stream: BytesIO) -> TriSurf:
-    tri_mesh: TriSurf = reader.load_obj_with_trimesh_from_binary(stream)
-    breakpoint()
-    raise NotImplementedError
+def OBJ_stream_to_trisurf(obj_stream: TextIO, mtl_stream: list[TextIO], texture_stream: list[io.BytesIO]) -> TriSurf:
+    tri_mesh: TriSurf = reader.load_obj_with_trimesh_from_binary(
+        obj_stream=obj_stream,
+        mtl_stream=mtl_stream,
+        texture_stream=texture_stream
+    )
+    return tri_mesh
 
 
 def VTK_stream_to_struct(stream: BytesIO, attribute_name: str) -> list[StructuredData]:

--- a/subsurface/modules/reader/__init__.py
+++ b/subsurface/modules/reader/__init__.py
@@ -7,3 +7,4 @@ from .topography.topo_core import read_structured_topography, read_unstructured_
 from .mesh.omf_mesh_reader import omf_stream_to_unstructs
 from .mesh.dxf_reader import dxf_stream_to_unstruct_input, dxf_file_to_unstruct_input
 from .mesh.mx_reader import mx_to_unstruc_from_binary
+from .mesh.obj_reader import load_obj_with_trimesh, load_obj_with_trimesh_from_binary

--- a/subsurface/modules/reader/__init__.py
+++ b/subsurface/modules/reader/__init__.py
@@ -8,3 +8,4 @@ from .mesh.omf_mesh_reader import omf_stream_to_unstructs
 from .mesh.dxf_reader import dxf_stream_to_unstruct_input, dxf_file_to_unstruct_input
 from .mesh.mx_reader import mx_to_unstruc_from_binary
 from .mesh.obj_reader import load_obj_with_trimesh, load_obj_with_trimesh_from_binary
+from .mesh.glb_reader import load_gltf_with_trimesh

--- a/subsurface/modules/reader/mesh/_trimesh_reader.py
+++ b/subsurface/modules/reader/mesh/_trimesh_reader.py
@@ -4,11 +4,9 @@ import io
 import os
 
 import numpy as np
-from subsurface.core.structs import UnstructuredData
-
-import subsurface
-from subsurface import optional_requirements
-from subsurface.core.structs import TriSurf, StructuredData
+from ....core.structs import UnstructuredData
+from .... import optional_requirements
+from ....core.structs import TriSurf, StructuredData
 
 
 class TriMeshTransformations(enum.Enum):
@@ -297,7 +295,8 @@ class TrimeshToSubsurface:
 
 class TriMeshReaderFromBlob:
     @classmethod
-    def OBJ_stream_to_trisurf(cls, obj_stream: TextIO, mtl_stream: list[TextIO], texture_stream: list[io.BytesIO]) -> TriSurf:
+    def OBJ_stream_to_trisurf(cls, obj_stream: TextIO, mtl_stream: list[TextIO],
+                              texture_stream: list[io.BytesIO], coord_system: TriMeshTransformations) -> TriSurf:
         """
         Load an OBJ file from a stream and convert it to a TriSurf object.
         
@@ -332,7 +331,11 @@ class TriMeshReaderFromBlob:
                 )
 
             # Now load the OBJ with all associated files available
-            scene_or_mesh = load_with_trimesh(obj_path, "obj", TriMeshTransformations.RIGHT_HANDED_Z_UP)
+            scene_or_mesh = load_with_trimesh(
+                path_to_file_or_buffer=obj_path,
+                file_type="obj",
+                coordinate_system=coord_system
+            )
 
             # Convert to a TriSurf object
             tri_surf = TrimeshToSubsurface.trimesh_to_unstruct(scene_or_mesh)

--- a/subsurface/modules/reader/mesh/_trimesh_reader.py
+++ b/subsurface/modules/reader/mesh/_trimesh_reader.py
@@ -220,6 +220,10 @@ class TrimeshToSubsurface:
         from PIL.PngImagePlugin import PngImageFile
         import trimesh
 
+
+        if geom.visual is None or getattr(geom.visual, 'material', None) is None:
+            return None
+
         array = np.empty(0)
         if isinstance(geom.visual.material, trimesh.visual.material.SimpleMaterial):
             image: JpegImageFile = geom.visual.material.image

--- a/subsurface/modules/reader/mesh/_trimesh_reader.py
+++ b/subsurface/modules/reader/mesh/_trimesh_reader.py
@@ -1,4 +1,5 @@
-from typing import Union, io
+from typing import Union, TextIO
+import io
 
 import numpy as np
 from subsurface.core.structs import UnstructuredData
@@ -8,235 +9,239 @@ from subsurface import optional_requirements
 from subsurface.core.structs import TriSurf, StructuredData
 
 
-def _load_with_trimesh(path_to_obj, plot=False):
-    plot = True
-    trimesh = optional_requirements.require_trimesh()
-    # Load the OBJ with Trimesh using the specified options
-    scene_or_mesh = trimesh.load(
-        file_obj=path_to_obj,
-        file_type="obj"
-    )
-    # Process single mesh vs. scene
-    if isinstance(scene_or_mesh, trimesh.Scene):
-        print("Loaded a Scene with multiple geometries.")
-        _process_scene(scene_or_mesh)
-        if plot:
-            scene_or_mesh.show()
-    else:
-        print("Loaded a single Trimesh object.")
-        print(f" - Vertices: {len(scene_or_mesh.vertices)}")
-        print(f" - Faces: {len(scene_or_mesh.faces)}")
-        _handle_material_info(scene_or_mesh)
-        if plot:
-            scene_or_mesh.show()
-    return scene_or_mesh
-
-
-def trimesh_to_unstruct(scene_or_mesh: Union["trimesh.Trimesh", "trimesh.Scene"]) -> TriSurf:
-    """
-    Convert a Trimesh or Scene object to a subsurface TriSurf object.
-
-    This function takes either a `trimesh.Trimesh` object or a `trimesh.Scene` 
-    object and converts it to a `subsurface.TriSurf` object. If the input is 
-    a scene containing multiple geometries, it processes all geometries and 
-    combines them into a single TriSurf object. If the input is a single 
-    Trimesh object, it directly converts it to a TriSurf object. An error 
-    is raised if the input is neither a `trimesh.Trimesh` nor a `trimesh.Scene` 
-    object.
-
-    Parameters:
-        scene_or_mesh (Union[trimesh.Trimesh, trimesh.Scene]): 
-            Input geometry data, either as a Trimesh object representing 
-            a single mesh or a Scene object containing multiple geometries.
-
-    Note:
-        ! Multimesh with multiple materials will read the uvs but not the textures since in that case is better
-        ! to read directly the multiple images (compressed) whenever the user wants to work with them. 
-
-    Returns:
-        subsurface.TriSurf: Converted subsurface representation of the 
-        provided geometry data.
-
-    Raises:
-        ValueError: If the input is neither a `trimesh.Trimesh` object nor 
-        a `trimesh.Scene` object.
-    """
-    trimesh = optional_requirements.require_trimesh()
-    if isinstance(scene_or_mesh, trimesh.Scene):
-        # Process scene with multiple geometries
-        ts = _trisurf_from_scene(scene_or_mesh, trimesh)
-
-    elif isinstance(scene_or_mesh, trimesh.Trimesh):
-        ts = _trisurf_from_trimesh(scene_or_mesh)
-
-
-    else:
-        raise ValueError("Input must be a Trimesh object or a Scene with multiple geometries.")
-
-    return ts
-
-
-def _trisurf_from_trimesh(scene_or_mesh):
-    # Process single mesh
-    tri = scene_or_mesh
-    pandas = optional_requirements.require_pandas()
-    frame = pandas.DataFrame(tri.face_attributes)
-    # Check frame has a valid shape for cells_attr if not make None
-    if frame.shape[0] != tri.faces.shape[0]:
-        frame = None
-    # Get UV coordinates if they exist
-    vertex_attr = None
-    if hasattr(tri.visual, 'uv') and tri.visual.uv is not None:
-        vertex_attr = pandas.DataFrame(
-            tri.visual.uv,
-            columns=['u', 'v']
+class LoadWithTrimesh:
+    @classmethod
+    def _load_with_trimesh(cls, path_to_obj, plot=False):
+        plot = True
+        trimesh = optional_requirements.require_trimesh()
+        # Load the OBJ with Trimesh using the specified options
+        scene_or_mesh = trimesh.load(
+            file_obj=path_to_obj,
+            file_type="obj"
         )
-    unstruct = UnstructuredData.from_array(
-        np.array(tri.vertices),
-        np.array(tri.faces),
-        cells_attr=frame,
-        vertex_attr=vertex_attr,
-        xarray_attributes={
-                "bounds": tri.bounds.tolist(),
-        },
-    )
+        # Process single mesh vs. scene
+        if isinstance(scene_or_mesh, trimesh.Scene):
+            print("Loaded a Scene with multiple geometries.")
+            cls._process_scene(scene_or_mesh)
+            if plot:
+                scene_or_mesh.show()
+        else:
+            print("Loaded a single Trimesh object.")
+            print(f" - Vertices: {len(scene_or_mesh.vertices)}")
+            print(f" - Faces: {len(scene_or_mesh.faces)}")
+            cls.handle_material_info(scene_or_mesh)
+            if plot:
+                scene_or_mesh.show()
+        return scene_or_mesh
 
-    texture = _extract_texture_from_material(tri)
+    @classmethod
+    def handle_material_info(cls, geometry):
+        """
+        Handle and print material information for a single geometry,
+        explicitly injecting the PIL image if provided.
+        """
+        if geometry.visual and hasattr(geometry.visual, 'material'):
+            material = geometry.visual.material
 
-    ts = TriSurf(
-        mesh=unstruct,
-        texture=texture,
-    )
-    return ts
+            print("Trimesh material:", material)
+
+            # If there's already an image reference in the material, let the user know
+            if hasattr(material, 'image') and material.image is not None:
+                print("  -> Material already has an image:", material.image)
+        else:
+            print("No material found or no 'material' attribute on this geometry.")
+
+    @classmethod
+    def _process_scene(cls, scene):
+        """Process a scene with multiple geometries."""
+        geometries = scene.geometry
+        assert len(geometries) > 0, "No geometries found in the scene."
+
+        print(f"Loaded a Scene with {len(scene.geometry)} geometry object(s).")
+        for geom_name, geom in geometries.items():
+            print(f" Submesh: {geom_name}")
+            print(f"  - Vertices: {len(geom.vertices)}")
+            print(f"  - Faces: {len(geom.faces)}")
+
+            print(f"Geometry '{geom_name}':")
+            cls.handle_material_info(geom)
 
 
-def _trisurf_from_scene(scene_or_mesh: 'Scene', trimesh: 'trimesh') -> TriSurf:
-    pandas = optional_requirements.require_pandas()
-    geometries = scene_or_mesh.geometry
-    assert len(geometries) > 0, "No geometries found in the scene."
-    all_vertex = []
-    all_cells = []
-    cell_attr = []
-    all_vertex_attr = []
-    _last_cell = 0
-    texture = None
-    for i, (geom_name, geom) in enumerate(geometries.items()):
-        geom: trimesh.Trimesh
-        _handle_material_info(geom)
+class TrimeshToSubsurface:
+    @classmethod
+    def trimesh_to_unstruct(cls, scene_or_mesh: Union["trimesh.Trimesh", "trimesh.Scene"]) -> TriSurf:
+        """
+        Convert a Trimesh or Scene object to a subsurface TriSurf object.
 
-        # Append vertices
-        all_vertex.append(np.array(geom.vertices))
+        This function takes either a `trimesh.Trimesh` object or a `trimesh.Scene` 
+        object and converts it to a `subsurface.TriSurf` object. If the input is 
+        a scene containing multiple geometries, it processes all geometries and 
+        combines them into a single TriSurf object. If the input is a single 
+        Trimesh object, it directly converts it to a TriSurf object. An error 
+        is raised if the input is neither a `trimesh.Trimesh` nor a `trimesh.Scene` 
+        object.
 
-        # Adjust cell indices and append
-        cells = np.array(geom.faces)
-        if len(all_cells) > 0:
-            cells = cells + _last_cell
-        all_cells.append(cells)
+        Parameters:
+            scene_or_mesh (Union[trimesh.Trimesh, trimesh.Scene]): 
+                Input geometry data, either as a Trimesh object representing 
+                a single mesh or a Scene object containing multiple geometries.
 
-        # Create attribute array for this geometry
-        cell_attr.append(np.ones(len(cells)) * i)
+        Note:
+            ! Multimesh with multiple materials will read the uvs but not the textures since in that case is better
+            ! to read directly the multiple images (compressed) whenever the user wants to work with them. 
 
-        _last_cell = cells.max() + 1
+        Returns:
+            subsurface.TriSurf: Converted subsurface representation of the 
+            provided geometry data.
 
+        Raises:
+            ValueError: If the input is neither a `trimesh.Trimesh` object nor 
+            a `trimesh.Scene` object.
+        """
+        trimesh = optional_requirements.require_trimesh()
+        if isinstance(scene_or_mesh, trimesh.Scene):
+            # Process scene with multiple geometries
+            ts = cls._trisurf_from_scene(scene_or_mesh, trimesh)
+
+        elif isinstance(scene_or_mesh, trimesh.Trimesh):
+            ts = cls._trisurf_from_trimesh(scene_or_mesh)
+
+
+        else:
+            raise ValueError("Input must be a Trimesh object or a Scene with multiple geometries.")
+
+        return ts
+
+    @classmethod
+    def _trisurf_from_trimesh(cls, scene_or_mesh):
+        # Process single mesh
+        tri = scene_or_mesh
+        pandas = optional_requirements.require_pandas()
+        frame = pandas.DataFrame(tri.face_attributes)
+        # Check frame has a valid shape for cells_attr if not make None
+        if frame.shape[0] != tri.faces.shape[0]:
+            frame = None
         # Get UV coordinates if they exist
-        if hasattr(geom.visual, 'uv') and geom.visual.uv is not None:
+        vertex_attr = None
+        if hasattr(tri.visual, 'uv') and tri.visual.uv is not None:
             vertex_attr = pandas.DataFrame(
-                geom.visual.uv,
+                tri.visual.uv,
                 columns=['u', 'v']
             )
-            all_vertex_attr.append(vertex_attr)
+        unstruct = UnstructuredData.from_array(
+            np.array(tri.vertices),
+            np.array(tri.faces),
+            cells_attr=frame,
+            vertex_attr=vertex_attr,
+            xarray_attributes={
+                    "bounds": tri.bounds.tolist(),
+            },
+        )
 
-        # Extract texture from material if it is only one geometry
-        if len(geometries) == 1:
-            texture = _extract_texture_from_material(geom)
+        texture = cls._extract_texture_from_material(tri)
 
-    # Create the combined UnstructuredData
-    unstruct = UnstructuredData.from_array(
-        vertex=np.vstack(all_vertex),
-        cells=np.vstack(all_cells),
-        vertex_attr=pandas.concat(all_vertex_attr, ignore_index=True) if len(all_vertex_attr) > 0 else None,
-        cells_attr=pandas.DataFrame(np.hstack(cell_attr), columns=["Geometry id"]),
-        xarray_attributes={
-                "bounds": scene_or_mesh.bounds.tolist(),
-        },
-    )
+        ts = TriSurf(
+            mesh=unstruct,
+            texture=texture,
+        )
+        return ts
 
-    # If there is a texture
-    ts = TriSurf(
-        mesh=unstruct,
-        texture=texture,
-    )
+    def _trisurf_from_scene(cls, scene_or_mesh: 'Scene', trimesh: 'trimesh') -> TriSurf:
+        pandas = optional_requirements.require_pandas()
+        geometries = scene_or_mesh.geometry
+        assert len(geometries) > 0, "No geometries found in the scene."
+        all_vertex = []
+        all_cells = []
+        cell_attr = []
+        all_vertex_attr = []
+        _last_cell = 0
+        texture = None
+        for i, (geom_name, geom) in enumerate(geometries.items()):
+            geom: trimesh.Trimesh
+            LoadWithTrimesh.handle_material_info(geom)
 
-    return ts
+            # Append vertices
+            all_vertex.append(np.array(geom.vertices))
 
+            # Adjust cell indices and append
+            cells = np.array(geom.faces)
+            if len(all_cells) > 0:
+                cells = cells + _last_cell
+            all_cells.append(cells)
 
-def _extract_texture_from_material(geom):
-    from PIL.JpegImagePlugin import JpegImageFile
-    from PIL.PngImagePlugin import PngImageFile
-    import trimesh
+            # Create attribute array for this geometry
+            cell_attr.append(np.ones(len(cells)) * i)
 
-    array = np.empty(0)
-    if isinstance(geom.visual.material, trimesh.visual.material.SimpleMaterial):
-        image: JpegImageFile = geom.visual.material.image
-        if image is None:
-            return None
-        array = np.array(image)
-    elif isinstance(geom.visual.material, trimesh.visual.material.PBRMaterial):
-        image: PngImageFile = geom.visual.material.baseColorTexture
-        array = np.array(image.convert('RGBA'))
+            _last_cell = cells.max() + 1
 
-        if image is None:
-            return None
-    else:
-        raise ValueError(f"Unsupported material type: {type(geom.visual.material)}")
+            # Get UV coordinates if they exist
+            if hasattr(geom.visual, 'uv') and geom.visual.uv is not None:
+                vertex_attr = pandas.DataFrame(
+                    geom.visual.uv,
+                    columns=['u', 'v']
+                )
+                all_vertex_attr.append(vertex_attr)
 
-    # Asser that image has 3 channels    assert array.shape[2] == 3    from PIL.PngImagePlugin import PngImageFile
-    assert array.shape[2] == 3 or array.shape[2] == 4
-    texture = StructuredData.from_numpy(array)
-    return texture
+            # Extract texture from material if it is only one geometry
+            if len(geometries) == 1:
+                texture = cls._extract_texture_from_material(geom)
 
+        # Create the combined UnstructuredData
+        unstruct = UnstructuredData.from_array(
+            vertex=np.vstack(all_vertex),
+            cells=np.vstack(all_cells),
+            vertex_attr=pandas.concat(all_vertex_attr, ignore_index=True) if len(all_vertex_attr) > 0 else None,
+            cells_attr=pandas.DataFrame(np.hstack(cell_attr), columns=["Geometry id"]),
+            xarray_attributes={
+                    "bounds": scene_or_mesh.bounds.tolist(),
+            },
+        )
 
-def _validate_texture_path(texture_path):
-    """Validate the texture file path."""
-    if texture_path and not texture_path.lower().endswith(('.png', '.jpg', '.jpeg')):
-        raise ValueError("Texture path must be a PNG or JPEG file")
+        # If there is a texture
+        ts = TriSurf(
+            mesh=unstruct,
+            texture=texture,
+        )
 
+        return ts
 
-def _handle_material_info(geometry):
-    """
-    Handle and print material information for a single geometry,
-    explicitly injecting the PIL image if provided.
-    """
-    if geometry.visual and hasattr(geometry.visual, 'material'):
-        material = geometry.visual.material
+    @classmethod
+    def _extract_texture_from_material(cls, geom):
+        from PIL.JpegImagePlugin import JpegImageFile
+        from PIL.PngImagePlugin import PngImageFile
+        import trimesh
 
-        print("Trimesh material:", material)
+        array = np.empty(0)
+        if isinstance(geom.visual.material, trimesh.visual.material.SimpleMaterial):
+            image: JpegImageFile = geom.visual.material.image
+            if image is None:
+                return None
+            array = np.array(image)
+        elif isinstance(geom.visual.material, trimesh.visual.material.PBRMaterial):
+            image: PngImageFile = geom.visual.material.baseColorTexture
+            array = np.array(image.convert('RGBA'))
 
-        # If there's already an image reference in the material, let the user know
-        if hasattr(material, 'image') and material.image is not None:
-            print("  -> Material already has an image:", material.image)
-    else:
-        print("No material found or no 'material' attribute on this geometry.")
+            if image is None:
+                return None
+        else:
+            raise ValueError(f"Unsupported material type: {type(geom.visual.material)}")
 
+        # Asser that image has 3 channels    assert array.shape[2] == 3    from PIL.PngImagePlugin import PngImageFile
+        assert array.shape[2] == 3 or array.shape[2] == 4
+        texture = StructuredData.from_numpy(array)
+        return texture
 
-def _process_scene(scene):
-    """Process a scene with multiple geometries."""
-    geometries = scene.geometry
-    assert len(geometries) > 0, "No geometries found in the scene."
-
-    print(f"Loaded a Scene with {len(scene.geometry)} geometry object(s).")
-    for geom_name, geom in geometries.items():
-        print(f" Submesh: {geom_name}")
-        print(f"  - Vertices: {len(geom.vertices)}")
-        print(f"  - Faces: {len(geom.faces)}")
-
-        print(f"Geometry '{geom_name}':")
-        _handle_material_info(geom)
+    @classmethod
+    def _validate_texture_path(cls, texture_path):
+        """Validate the texture file path."""
+        if texture_path and not texture_path.lower().endswith(('.png', '.jpg', '.jpeg')):
+            raise ValueError("Texture path must be a PNG or JPEG file")
 
 
 class TriMeshReaderFromBlob:
     @classmethod
-    def OBJ_stream_to_trisurf(cls, obj_stream: io.TextIO, mtl_stream: io.BytesIO, texture_stream: io.BytesIO) -> TriSurf:
+    def OBJ_stream_to_trisurf(cls, obj_stream: TextIO, mtl_stream: io.BytesIO, texture_stream: io.BytesIO) -> \
+            TriSurf:
         """
         Load an OBJ file from a stream and convert it to a TriSurf object.
         
@@ -311,7 +316,7 @@ class TriMeshReaderFromBlob:
             scene_or_mesh = trimesh.load(obj_path)
 
             # Convert to a TriSurf object
-            tri_surf = trimesh_to_unstruct(scene_or_mesh)
+            tri_surf = TrimeshToSubsurface.trimesh_to_unstruct(scene_or_mesh)
 
         return tri_surf
 

--- a/subsurface/modules/reader/mesh/_trimesh_reader.py
+++ b/subsurface/modules/reader/mesh/_trimesh_reader.py
@@ -10,8 +10,8 @@ from subsurface import optional_requirements
 from subsurface.core.structs import TriSurf, StructuredData
 
 
-def _load_with_trimesh(path_to_obj, file_type: Optional[str] = None, plot=False):
-    return LoadWithTrimesh.load_with_trimesh(path_to_obj, file_type, plot)
+def _load_with_trimesh(path_to_file_or_buffer, file_type: Optional[str] = None, plot=False):
+    return LoadWithTrimesh.load_with_trimesh(path_to_file_or_buffer, file_type, plot)
 
 
 def trimesh_to_unstruct(scene_or_mesh: Union["trimesh.Trimesh", "trimesh.Scene"]) -> TriSurf:
@@ -20,12 +20,13 @@ def trimesh_to_unstruct(scene_or_mesh: Union["trimesh.Trimesh", "trimesh.Scene"]
 
 class LoadWithTrimesh:
     @classmethod
-    def load_with_trimesh(cls, path_to_obj, file_type: Optional[str] = None, plot=False):
+    def load_with_trimesh(cls, path_to_file_or_buffer, file_type: Optional[str] = None, plot=False):
         trimesh = optional_requirements.require_trimesh()
         # Load the OBJ with Trimesh using the specified options
         scene_or_mesh = trimesh.load(
-            file_obj=path_to_obj,
-            file_type=file_type
+            file_obj=path_to_file_or_buffer,
+            file_type=file_type,
+            force="mesh"
         )
         # Process single mesh vs. scene
         if isinstance(scene_or_mesh, trimesh.Scene):

--- a/subsurface/modules/reader/mesh/glb_reader.py
+++ b/subsurface/modules/reader/mesh/glb_reader.py
@@ -2,7 +2,7 @@ import io
 from typing import Union
 
 from ....core.structs import TriSurf
-from ._trimesh_reader import _load_with_trimesh, trimesh_to_unstruct
+from ._trimesh_reader import load_with_trimesh, trimesh_to_unstruct
 
 
 def load_gltf_with_trimesh(path_to_glb: Union[str | io.BytesIO], plot: bool = False) -> TriSurf:
@@ -25,6 +25,6 @@ def load_gltf_with_trimesh(path_to_glb: Union[str | io.BytesIO], plot: bool = Fa
     subsurface.TriSurf
         A TriSurf object representing the processed 3D surface geometry.
     """
-    trimesh = _load_with_trimesh(path_to_glb, file_type="glb", plot=plot)
+    trimesh = load_with_trimesh(path_to_glb, file_type="glb", plot=plot)
     trisurf = trimesh_to_unstruct(trimesh)
     return trisurf

--- a/subsurface/modules/reader/mesh/glb_reader.py
+++ b/subsurface/modules/reader/mesh/glb_reader.py
@@ -2,10 +2,10 @@ import io
 from typing import Union
 
 from ....core.structs import TriSurf
-from ._trimesh_reader import load_with_trimesh, trimesh_to_unstruct
+from ._trimesh_reader import load_with_trimesh, trimesh_to_unstruct, TriMeshTransformations
 
 
-def load_gltf_with_trimesh(path_to_glb: Union[str | io.BytesIO], plot: bool = False) -> TriSurf:
+def load_gltf_with_trimesh(path_to_glb: Union[str | io.BytesIO], coordinate_system: TriMeshTransformations) -> TriSurf:
     """
     load_obj_with_trimesh(path_to_glb, plot=False)
 
@@ -25,6 +25,6 @@ def load_gltf_with_trimesh(path_to_glb: Union[str | io.BytesIO], plot: bool = Fa
     subsurface.TriSurf
         A TriSurf object representing the processed 3D surface geometry.
     """
-    trimesh = load_with_trimesh(path_to_glb, file_type="glb", plot=plot)
+    trimesh = load_with_trimesh(path_to_glb, file_type="glb", coordinate_system=coordinate_system, plot=False)
     trisurf = trimesh_to_unstruct(trimesh)
     return trisurf

--- a/subsurface/modules/reader/mesh/glb_reader.py
+++ b/subsurface/modules/reader/mesh/glb_reader.py
@@ -1,8 +1,11 @@
-import subsurface
-from subsurface.modules.reader.mesh._trimesh_reader import _load_with_trimesh, trimesh_to_unstruct
+import io
+from typing import Union
+
+from ....core.structs import TriSurf
+from ._trimesh_reader import _load_with_trimesh, trimesh_to_unstruct
 
 
-def load_glb_with_trimesh(path_to_glb: str, plot: bool = False) -> subsurface.TriSurf:
+def load_gltf_with_trimesh(path_to_glb: Union[str | io.BytesIO], plot: bool = False) -> TriSurf:
     """
     load_obj_with_trimesh(path_to_glb, plot=False)
 
@@ -22,6 +25,6 @@ def load_glb_with_trimesh(path_to_glb: str, plot: bool = False) -> subsurface.Tr
     subsurface.TriSurf
         A TriSurf object representing the processed 3D surface geometry.
     """
-    trimesh = _load_with_trimesh(path_to_glb, plot)
+    trimesh = _load_with_trimesh(path_to_glb, file_type="glb", plot=plot)
     trisurf = trimesh_to_unstruct(trimesh)
     return trisurf

--- a/subsurface/modules/reader/mesh/obj_reader.py
+++ b/subsurface/modules/reader/mesh/obj_reader.py
@@ -1,16 +1,18 @@
 ﻿from typing import Union, TextIO
 import io
 
-from ._trimesh_reader import load_with_trimesh, trimesh_to_unstruct, TriMeshReaderFromBlob
+from ._trimesh_reader import load_with_trimesh, trimesh_to_unstruct, TriMeshReaderFromBlob, TriMeshTransformations
 from ....core.structs import TriSurf
 
 
 
-def load_obj_with_trimesh_from_binary(obj_stream: TextIO, mtl_stream: list[TextIO], texture_stream: list[io.BytesIO]) -> TriSurf:
+def load_obj_with_trimesh_from_binary(obj_stream: TextIO, mtl_stream: list[TextIO], 
+                                      texture_stream: list[io.BytesIO], coord_system: TriMeshTransformations) -> TriSurf:
     tri_surf: TriSurf = TriMeshReaderFromBlob.OBJ_stream_to_trisurf(
         obj_stream=obj_stream,
         mtl_stream=mtl_stream,
-        texture_stream=texture_stream
+        texture_stream=texture_stream,
+        coord_system=coord_system
     )
     
     return tri_surf

--- a/subsurface/modules/reader/mesh/obj_reader.py
+++ b/subsurface/modules/reader/mesh/obj_reader.py
@@ -1,10 +1,22 @@
-﻿from typing import Union
+﻿from typing import Union, TextIO
 
-import subsurface
-from subsurface.modules.reader.mesh._trimesh_reader import _load_with_trimesh, trimesh_to_unstruct
+from ._trimesh_reader import _load_with_trimesh, trimesh_to_unstruct, TriMeshReaderFromBlob
+from ....core.structs import TriSurf
 
 
-def load_obj_with_trimesh(path_to_obj: str, plot: bool = False) -> subsurface.TriSurf:
+def load_obj_with_trimesh_from_binary(stream: TextIO):
+    tri_surf: TriSurf = TriMeshReaderFromBlob.OBJ_stream_to_trisurf(
+        obj_stream=stream,
+        mtl_stream=None,
+        texture_stream=None
+    )
+    
+    return tri_surf
+    
+    # TODO: Somehow call here trimesh
+
+
+def load_obj_with_trimesh(path_to_obj: str, plot: bool = False) -> TriSurf:
     """
     Load and process an OBJ file, returning trimesh-compatible objects.
 

--- a/subsurface/modules/reader/mesh/obj_reader.py
+++ b/subsurface/modules/reader/mesh/obj_reader.py
@@ -1,20 +1,20 @@
 ﻿from typing import Union, TextIO
+import io
 
 from ._trimesh_reader import _load_with_trimesh, trimesh_to_unstruct, TriMeshReaderFromBlob
 from ....core.structs import TriSurf
 
 
-def load_obj_with_trimesh_from_binary(stream: TextIO):
+
+def load_obj_with_trimesh_from_binary(obj_stream: TextIO, mtl_stream: list[TextIO], texture_stream: list[io.BytesIO]) -> TriSurf:
     tri_surf: TriSurf = TriMeshReaderFromBlob.OBJ_stream_to_trisurf(
-        obj_stream=stream,
-        mtl_stream=None,
-        texture_stream=None
+        obj_stream=obj_stream,
+        mtl_stream=mtl_stream,
+        texture_stream=texture_stream
     )
     
     return tri_surf
     
-    # TODO: Somehow call here trimesh
-
 
 def load_obj_with_trimesh(path_to_obj: str, plot: bool = False) -> TriSurf:
     """

--- a/subsurface/modules/reader/mesh/obj_reader.py
+++ b/subsurface/modules/reader/mesh/obj_reader.py
@@ -1,7 +1,7 @@
 ﻿from typing import Union, TextIO
 import io
 
-from ._trimesh_reader import _load_with_trimesh, trimesh_to_unstruct, TriMeshReaderFromBlob
+from ._trimesh_reader import load_with_trimesh, trimesh_to_unstruct, TriMeshReaderFromBlob
 from ....core.structs import TriSurf
 
 
@@ -46,6 +46,6 @@ def load_obj_with_trimesh(path_to_obj: str, plot: bool = False) -> TriSurf:
         `ValueError`: If the OBJ file could not be properly processed.
 
     """
-    trimesh = _load_with_trimesh(path_to_obj, file_type="obj", plot=plot)
+    trimesh = load_with_trimesh(path_to_obj, file_type="obj", plot=plot)
     trisurf = trimesh_to_unstruct(trimesh)
     return trisurf

--- a/subsurface/modules/reader/mesh/obj_reader.py
+++ b/subsurface/modules/reader/mesh/obj_reader.py
@@ -46,6 +46,6 @@ def load_obj_with_trimesh(path_to_obj: str, plot: bool = False) -> TriSurf:
         `ValueError`: If the OBJ file could not be properly processed.
 
     """
-    trimesh = _load_with_trimesh(path_to_obj, plot)
+    trimesh = _load_with_trimesh(path_to_obj, file_type="obj", plot=plot)
     trisurf = trimesh_to_unstruct(trimesh)
     return trisurf

--- a/subsurface/modules/reader/wells/read_borehole_interface.py
+++ b/subsurface/modules/reader/wells/read_borehole_interface.py
@@ -22,13 +22,16 @@ def read_collar(reader_helper: GenericReaderFilesHelper) -> pd.DataFrame:
     return data_df
 
 
-def read_survey(reader_helper: GenericReaderFilesHelper):
+def read_survey(reader_helper: GenericReaderFilesHelper, validate_survey: bool = True) -> pd.DataFrame:
     if reader_helper.index_col is False: reader_helper.index_col = 0
 
     d = check_format_and_read_to_df(reader_helper)
     _map_rows_and_cols_inplace(d, reader_helper)
 
-    d_no_singles = _validate_survey_data(d)
+    if validate_survey:
+        d_no_singles = _validate_survey_data(d)
+    else:
+        d_no_singles = d
 
     return d_no_singles
 
@@ -37,12 +40,16 @@ def read_lith(reader_helper: GenericReaderFilesHelper) -> pd.DataFrame:
     return read_attributes(reader_helper, is_lith=True)
 
 
-def read_attributes(reader_helper: GenericReaderFilesHelper, is_lith: bool = False) -> pd.DataFrame:
-    if reader_helper.index_col is False: reader_helper.index_col = 0
-
+def read_attributes(reader_helper: GenericReaderFilesHelper, is_lith: bool = False, validate_attr: bool = True) -> pd.DataFrame:
+    if reader_helper.index_col is False:
+        reader_helper.index_col = 0
+        
     d = check_format_and_read_to_df(reader_helper)
 
     _map_rows_and_cols_inplace(d, reader_helper)
+    if validate_attr is False:
+        return d
+    
     if is_lith:
         d = _validate_lith_data(d, reader_helper)
     else:

--- a/subsurface/modules/reader/wells/read_borehole_interface.py
+++ b/subsurface/modules/reader/wells/read_borehole_interface.py
@@ -9,7 +9,6 @@ from subsurface.modules.reader.wells.wells_utils import add_tops_from_base_and_a
 
 
 def read_collar(reader_helper: GenericReaderFilesHelper) -> pd.DataFrame:
-    if reader_helper.usecols is None: reader_helper.usecols = [0, 1, 2, 3]
     if reader_helper.index_col is False: reader_helper.index_col = 0
 
     # Check file_or_buffer type

--- a/tests/test_io/test_meshes/test_glf.py
+++ b/tests/test_io/test_meshes/test_glf.py
@@ -1,18 +1,12 @@
 import os
 
-import pytest
 import dotenv
-
-from subsurface import optional_requirements
-from subsurface.modules.reader.mesh.glb_reader import load_glb_with_trimesh
-from subsurface.modules.reader.mesh.obj_reader import load_obj_with_trimesh
-from tests.conftest import RequirementsLevel
+import pytest
 
 import subsurface
+from subsurface.modules.reader.mesh.glb_reader import load_glb_with_trimesh
 from subsurface.modules.visualization import to_pyvista_mesh, pv_plot
-
-from subsurface import optional_requirements, TriSurf
-from subsurface.modules.reader.mesh.obj_reader import load_obj_with_trimesh, trimesh_to_unstruct
+from tests.conftest import RequirementsLevel
 
 dotenv.load_dotenv()
 
@@ -29,7 +23,6 @@ def test_trimesh_read_glb_complex():
     If it's a scene, we iterate over submeshes; 
     if it's a single mesh, we inspect it directly.
     """
-    import trimesh
 
     glb_path = os.getenv("PATH_TO_GLB_COMPLEX")
     # glb_path = os.getenv("PATH_TO_GLB")

--- a/tests/test_io/test_meshes/test_glf.py
+++ b/tests/test_io/test_meshes/test_glf.py
@@ -4,6 +4,7 @@ import dotenv
 import pytest
 
 import subsurface
+from subsurface.modules.reader.mesh._trimesh_reader import TriMeshTransformations
 from subsurface.modules.reader.mesh.glb_reader import load_gltf_with_trimesh
 from subsurface.modules.visualization import to_pyvista_mesh, pv_plot
 from tests.conftest import RequirementsLevel
@@ -30,7 +31,7 @@ def test_trimesh_read_glb_complex():
 
     # Trimesh can load GLB/GLTF natively
 
-    ts: subsurface.TriSurf = load_gltf_with_trimesh(glb_path)
+    ts: subsurface.TriSurf = load_gltf_with_trimesh(glb_path, TriMeshTransformations.RIGHT_HANDED_Z_UP)
     s = to_pyvista_mesh(ts)
     pv_plot([s], image_2d=True)
     return
@@ -48,7 +49,7 @@ def test_trimesh_read_glb():
 
     # Trimesh can load GLB/GLTF natively
 
-    ts = load_gltf_with_trimesh(glb_path, plot=False)
+    ts = load_gltf_with_trimesh(glb_path, TriMeshTransformations.RIGHT_HANDED_Z_UP)
     s = to_pyvista_mesh(ts)
     pv_plot([s], image_2d=True)
     return 

--- a/tests/test_io/test_meshes/test_glf.py
+++ b/tests/test_io/test_meshes/test_glf.py
@@ -4,7 +4,7 @@ import dotenv
 import pytest
 
 import subsurface
-from subsurface.modules.reader.mesh.glb_reader import load_glb_with_trimesh
+from subsurface.modules.reader.mesh.glb_reader import load_gltf_with_trimesh
 from subsurface.modules.visualization import to_pyvista_mesh, pv_plot
 from tests.conftest import RequirementsLevel
 
@@ -30,7 +30,7 @@ def test_trimesh_read_glb_complex():
 
     # Trimesh can load GLB/GLTF natively
 
-    ts: subsurface.TriSurf = load_glb_with_trimesh(glb_path)
+    ts: subsurface.TriSurf = load_gltf_with_trimesh(glb_path)
     s = to_pyvista_mesh(ts)
     pv_plot([s], image_2d=True)
     return
@@ -48,7 +48,7 @@ def test_trimesh_read_glb():
 
     # Trimesh can load GLB/GLTF natively
 
-    ts = load_glb_with_trimesh(glb_path, plot=False)
+    ts = load_gltf_with_trimesh(glb_path, plot=False)
     s = to_pyvista_mesh(ts)
     pv_plot([s], image_2d=True)
     return 

--- a/tests/test_io/test_meshes/test_read_obj.py
+++ b/tests/test_io/test_meshes/test_read_obj.py
@@ -7,7 +7,7 @@ import subsurface
 from subsurface.modules.visualization import to_pyvista_mesh, pv_plot
 
 from subsurface import optional_requirements
-from subsurface.modules.reader.mesh._trimesh_reader import trimesh_to_unstruct, load_with_trimesh
+from subsurface.modules.reader.mesh._trimesh_reader import trimesh_to_unstruct, load_with_trimesh, TriMeshTransformations
 
 dotenv.load_dotenv()
 
@@ -81,7 +81,7 @@ def test_trimesh_one_element_no_texture_to_unstruct():
     ts = trimesh_to_unstruct(trimesh_obj)
 
     s = to_pyvista_mesh(ts)
-    pv_plot([s], image_2d=False)
+    pv_plot([s], image_2d=True)
 
 
 def test_trimesh_three_element_no_texture_to_unstruct():
@@ -111,7 +111,7 @@ def test_trimesh_three_element_texture_to_unstruct():
     multiple images as structured objects
     """
     path_to_obj = os.getenv("PATH_TO_OBJ_SCANS")
-    trimesh_obj = load_with_trimesh(path_to_obj)
+    trimesh_obj = load_with_trimesh(path_to_obj, coordinate_system=TriMeshTransformations.ORIGINAL)
 
     ts = trimesh_to_unstruct(trimesh_obj)
 

--- a/tests/test_io/test_meshes/test_read_obj.py
+++ b/tests/test_io/test_meshes/test_read_obj.py
@@ -7,7 +7,7 @@ import subsurface
 from subsurface.modules.visualization import to_pyvista_mesh, pv_plot
 
 from subsurface import optional_requirements
-from subsurface.modules.reader.mesh._trimesh_reader import trimesh_to_unstruct, _load_with_trimesh
+from subsurface.modules.reader.mesh._trimesh_reader import trimesh_to_unstruct, load_with_trimesh
 
 dotenv.load_dotenv()
 
@@ -34,39 +34,39 @@ def test_trimesh_load_obj_with_mtl_submeshes_heavy():
 
     assert os.path.exists(path_to_obj), f"OBJ not found: {path_to_obj}"
     assert os.path.exists(path_to_mtl), f"MTL not found: {path_to_mtl}"
-    _load_with_trimesh(path_to_obj, plot=False)
+    load_with_trimesh(path_to_obj, plot=False)
 
 
 def test_trimesh_load_obj_with_mtl_submeshes_II():
     # Replace these with the actual paths in your environment
     path_to_obj = os.getenv("PATH_TO_OBJ_MULTIMATERIAL_II")
-    _load_with_trimesh(path_to_obj, plot=False)
+    load_with_trimesh(path_to_obj, plot=False)
 
 
 def test_trimesh_load_obj_with_jpg_texture():
     path_to_obj = os.getenv("TERRA_PATH_DEVOPS") + "/meshes/OBJ/Portugal outcrop decimated/textured_output.obj"
-    _load_with_trimesh(path_to_obj)
+    load_with_trimesh(path_to_obj)
 
 
 def test_trimesh_load_obj_with_face_I():
     path_to_obj = os.getenv("PATH_TO_OBJ_FACE_I")
-    _load_with_trimesh(path_to_obj, plot=False)
+    load_with_trimesh(path_to_obj, plot=False)
 
 
 def test_trimesh_load_obj_with_face_II():
     path_to_obj = os.getenv("PATH_TO_OBJ_FACE_II")
-    _load_with_trimesh(path_to_obj, plot=False)
+    load_with_trimesh(path_to_obj, plot=False)
 
 
 def test_trimesh_load_obj_boxes():
     path_to_obj = os.getenv("PATH_TO_OBJ_SCANS")
-    _load_with_trimesh(path_to_obj)
+    load_with_trimesh(path_to_obj)
 
 
 def test_trimesh_load_obj_with_texture_II():
     """Penguin, material exist but png is not loading correctly"""
     path_to_obj = os.getenv("TERRA_PATH_DEVOPS") + "/meshes/OBJ/TexturedMesh/PenguinBaseMesh.obj"
-    _load_with_trimesh(
+    load_with_trimesh(
         path_to_file_or_buffer=path_to_obj,
         plot=False
     )
@@ -74,19 +74,19 @@ def test_trimesh_load_obj_with_texture_II():
 
 def test_trimesh_one_element_no_texture_to_unstruct():
     path_to_obj = os.getenv("TERRA_PATH_DEVOPS") + "/meshes/OBJ/TexturedMesh/PenguinBaseMesh.obj"
-    trimesh_obj = _load_with_trimesh(
+    trimesh_obj = load_with_trimesh(
         path_to_file_or_buffer=path_to_obj,
         plot=False
     )
     ts = trimesh_to_unstruct(trimesh_obj)
 
     s = to_pyvista_mesh(ts)
-    pv_plot([s], image_2d=True)
+    pv_plot([s], image_2d=False)
 
 
 def test_trimesh_three_element_no_texture_to_unstruct():
     path_to_obj = os.getenv("PATH_TO_OBJ_MULTIMATERIAL_II")
-    trimesh_obj = _load_with_trimesh(path_to_obj)
+    trimesh_obj = load_with_trimesh(path_to_obj)
 
     ts = trimesh_to_unstruct(trimesh_obj)
 
@@ -95,7 +95,7 @@ def test_trimesh_three_element_no_texture_to_unstruct():
 
 
 def test_trimesh_ONE_element_texture_to_unstruct():
-    trimesh_obj = _load_with_trimesh(
+    trimesh_obj = load_with_trimesh(
         path_to_file_or_buffer=(os.getenv("PATH_TO_OBJ_FACE_II")),
         plot=False
     )
@@ -111,7 +111,7 @@ def test_trimesh_three_element_texture_to_unstruct():
     multiple images as structured objects
     """
     path_to_obj = os.getenv("PATH_TO_OBJ_SCANS")
-    trimesh_obj = _load_with_trimesh(path_to_obj)
+    trimesh_obj = load_with_trimesh(path_to_obj)
 
     ts = trimesh_to_unstruct(trimesh_obj)
 

--- a/tests/test_io/test_meshes/test_read_obj.py
+++ b/tests/test_io/test_meshes/test_read_obj.py
@@ -67,7 +67,7 @@ def test_trimesh_load_obj_with_texture_II():
     """Penguin, material exist but png is not loading correctly"""
     path_to_obj = os.getenv("TERRA_PATH_DEVOPS") + "/meshes/OBJ/TexturedMesh/PenguinBaseMesh.obj"
     _load_with_trimesh(
-        path_to_obj=path_to_obj,
+        path_to_file_or_buffer=path_to_obj,
         plot=False
     )
 
@@ -75,7 +75,7 @@ def test_trimesh_load_obj_with_texture_II():
 def test_trimesh_one_element_no_texture_to_unstruct():
     path_to_obj = os.getenv("TERRA_PATH_DEVOPS") + "/meshes/OBJ/TexturedMesh/PenguinBaseMesh.obj"
     trimesh_obj = _load_with_trimesh(
-        path_to_obj=path_to_obj,
+        path_to_file_or_buffer=path_to_obj,
         plot=False
     )
     ts = trimesh_to_unstruct(trimesh_obj)
@@ -96,7 +96,7 @@ def test_trimesh_three_element_no_texture_to_unstruct():
 
 def test_trimesh_ONE_element_texture_to_unstruct():
     trimesh_obj = _load_with_trimesh(
-        path_to_obj=(os.getenv("PATH_TO_OBJ_FACE_II")),
+        path_to_file_or_buffer=(os.getenv("PATH_TO_OBJ_FACE_II")),
         plot=False
     )
 


### PR DESCRIPTION
# Add OBJ and GLTF mesh readers with coordinate system transformations

Added support for loading OBJ and GLTF/GLB 3D mesh files with proper coordinate system handling. The implementation includes:

- New API functions `OBJ_stream_to_trisurf` and `GLTF_stream_to_trisurf` for loading meshes from streams
- Coordinate system transformation options to convert between modeling software coordinates (Y-up) and scientific coordinates (Z-up)
- Support for loading textures and materials from OBJ/MTL files
- Refactored trimesh reader code into more maintainable classes
- Added `validate_survey` and `validate_attr` arguments to enable or bypass validation in `read_survey` and `read_attributes` respectively. This improves flexibility by allowing users to skip validation when not needed.