### PR TITLE
[ENH] Add function to clip NaN points in borehole visualization | GEN-10672

### DIFF
--- a/requirements/requirements_wells.txt
+++ b/requirements/requirements_wells.txt
@@ -1,3 +1,4 @@
 openpyxl
 wellpathpy
+scipy
 

--- a/subsurface/modules/reader/mesh/_trimesh_reader.py
+++ b/subsurface/modules/reader/mesh/_trimesh_reader.py
@@ -37,9 +37,9 @@ def load_with_trimesh(path_to_file_or_buffer, file_type: Optional[str] = None,
             # Old Z axis → New -Y axis
             # Old X axis → Remains as X axis
             transform = np.array([
-                    [-1, 0, 0, 0],  
-                    [0, 0, 1, 0],  
-                    [0, 1, 0, 0], 
+                    [1, 0, 0, 0],  # X → X
+                    [0, 0, 1, 0],  # Y → Z 
+                    [0, 1, 0, 0],  # Z → -Y
                     [0, 0, 0, 1]
             ])
 

--- a/subsurface/modules/reader/mesh/_trimesh_reader.py
+++ b/subsurface/modules/reader/mesh/_trimesh_reader.py
@@ -37,9 +37,9 @@ def load_with_trimesh(path_to_file_or_buffer, file_type: Optional[str] = None,
             # Old Z axis → New -Y axis
             # Old X axis → Remains as X axis
             transform = np.array([
-                    [1, 0, 0, 0],  # X → X
-                    [0, 0, 1, 0],  # Y → Z 
-                    [0, 1, 0, 0],  # Z → -Y
+                    [-1, 0, 0, 0],  
+                    [0, 0, 1, 0],  
+                    [0, 1, 0, 0], 
                     [0, 0, 0, 1]
             ])
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,7 +36,7 @@ class RequirementsLevel(enum.Flag):
 
 
 def check_requirements(minimum_level: RequirementsLevel):
-    return RequirementsLevel.REQUIREMENT_LEVEL_TO_TEST().value < minimum_level.value
+    return minimum_level not in RequirementsLevel.REQUIREMENT_LEVEL_TO_TEST(),
 
 
 def pytest_configure(config):

--- a/tests/test_io/test_combined/test_read_OMF.py
+++ b/tests/test_io/test_combined/test_read_OMF.py
@@ -1,6 +1,7 @@
-import numpy as np
-from dotenv import dotenv_values
+import os
 
+import dotenv
+import numpy as np
 import subsurface
 from tests.conftest import RequirementsLevel
 from subsurface import optional_requirements, TriSurf
@@ -14,11 +15,11 @@ pytestmark = pytest.mark.skipif(
     reason="Need to set READ_MESH"
 )
 
+dotenv.load_dotenv()
 
 @pytest.fixture(scope="module")
 def load_omf():
-    config = dotenv_values()
-    path = config.get('PATH_TO_OMF')
+    path = os.getenv('PATH_TO_OMF')
     omfvista = optional_requirements.require_omf()
     omf = omfvista.load_project(path)
     return omf

--- a/tests/test_io/test_combined/test_read_OMF.py
+++ b/tests/test_io/test_combined/test_read_OMF.py
@@ -111,17 +111,3 @@ def test_omf_to_unstruct_all_surfaces_to_one_unstructured_data(load_omf):
     list_of_polydata.append(s)
     pv_plot(list_of_polydata, image_2d=True)
 
-
-def test_omf_from_stream_to_unstruct_all_surfaces():
-    pyvista = optional_requirements.require_pyvista()
-
-    path = os.getenv('PATH_TO_OMF')
-    omf = load_omf
-    with open(path, "rb") as stream:
-        from subsurface.modules.reader import omf_stream_to_unstructs
-        unstruct = omf_stream_to_unstructs(stream)
-
-    ts: subsurface.TriSurf = TriSurf(mesh=unstruct)
-    s: pyvista.PolyData = to_pyvista_mesh(ts)
-
-    pv_plot([s], image_2d=True)

--- a/tests/test_io/test_combined/test_read_OMF.py
+++ b/tests/test_io/test_combined/test_read_OMF.py
@@ -115,8 +115,8 @@ def test_omf_to_unstruct_all_surfaces_to_one_unstructured_data(load_omf):
 def test_omf_from_stream_to_unstruct_all_surfaces():
     pyvista = optional_requirements.require_pyvista()
 
-    config = dotenv_values()
-    path = config.get('PATH_TO_OMF')
+    path = os.getenv('PATH_TO_OMF')
+    omf = load_omf
     with open(path, "rb") as stream:
         from subsurface.modules.reader import omf_stream_to_unstructs
         unstruct = omf_stream_to_unstructs(stream)

--- a/tests/test_io/test_combined/test_read_OMF_to_well.py
+++ b/tests/test_io/test_combined/test_read_OMF_to_well.py
@@ -1,5 +1,7 @@
-﻿import pytest
-from dotenv import dotenv_values
+﻿import os
+
+import pytest
+import dotenv
 
 import subsurface
 from tests.conftest import RequirementsLevel
@@ -7,6 +9,7 @@ from subsurface import LineSet, UnstructuredData, PointSet, optional_requirement
 from subsurface.modules.visualization import pv_plot, to_pyvista_line, to_pyvista_points, PyvistaScalarType
 from subsurface.modules.writer import base_structs_to_binary_file
 
+dotenv.load_dotenv()
 pytestmark = pytest.mark.skipif(
     condition=(RequirementsLevel.READ_MESH) not in RequirementsLevel.REQUIREMENT_LEVEL_TO_TEST(),
     reason="Need to set READ_MESH"
@@ -16,8 +19,7 @@ pytestmark = pytest.mark.skipif(
 
 @pytest.fixture(scope="module")
 def load_omf():
-    config = dotenv_values()
-    path = config.get('PATH_TO_BOLIDEN')
+    path = os.getenv("PATH_TO_BOLIDEN")
     omfvista = optional_requirements.require_omf()
     omf = omfvista.load_project(path)
 

--- a/tests/test_io/test_lines/_aux_func.py
+++ b/tests/test_io/test_lines/_aux_func.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from subsurface.modules.visualization import to_pyvista_line, init_plotter, to_pyvista_points, pyvista_to_matplotlib
 
 
@@ -7,13 +9,14 @@ def _plot(scalar, trajectory, collars=None, lut:int=100, image_2d=True):
         active_scalar=scalar,
         radius=10
     )
-    
-    
+
+    s = clip_nan_points(s, scalar_name=scalar)
     p = init_plotter(image_2d=image_2d)
     import matplotlib.pyplot as plt
     boring_cmap = plt.get_cmap("viridis", lut)
     p.add_mesh(s, cmap=boring_cmap)
     p.add_axes()
+    # Clip nans
 
     if collars is not None:
         collar_mesh = to_pyvista_points(collars.collar_loc)
@@ -31,3 +34,23 @@ def _plot(scalar, trajectory, collars=None, lut:int=100, image_2d=True):
         p.close()
     else:
         p.show()
+
+def clip_nan_points(mesh, scalar_name):
+    import pyvista as pv
+    # Extract the scalar array
+    scalars = mesh.point_data[scalar_name]
+    
+    # Identify valid (non-NaN) points
+    valid_mask = ~np.isnan(scalars)
+    
+    # Apply the mask to filter points and scalars
+    filtered_points = mesh.points[valid_mask]
+    filtered_scalars = scalars[valid_mask]
+    
+    # Create a new PyVista mesh with the filtered data
+    filtered_mesh = pv.PolyData(filtered_points)
+    filtered_mesh.point_data[scalar_name] = filtered_scalars
+    
+    return filtered_mesh
+
+# Example usage

--- a/tests/test_io/test_lines/test_lines_I.py
+++ b/tests/test_io/test_lines/test_lines_I.py
@@ -1,7 +1,9 @@
 import dotenv
 import os
 import pandas as pd
+import pytest
 
+from conftest import RequirementsLevel
 from subsurface import UnstructuredData
 from subsurface.api.reader.read_wells import read_wells
 from subsurface.core.geological_formats.boreholes.boreholes import BoreholeSet, MergeOptions
@@ -18,6 +20,10 @@ dotenv.load_dotenv()
 
 PLOT = True
 
+pytestmark = pytest.mark.skipif(
+    condition=(RequirementsLevel.READ_WELL) not in RequirementsLevel.REQUIREMENT_LEVEL_TO_TEST(),
+    reason="Need to set the READ_MESH"
+)
 
 def test_read_collar():
     reader: GenericReaderFilesHelper = GenericReaderFilesHelper(

--- a/tests/test_io/test_lines/test_lines_I.py
+++ b/tests/test_io/test_lines/test_lines_I.py
@@ -3,7 +3,6 @@ import os
 import pandas as pd
 import pytest
 
-from conftest import RequirementsLevel
 from subsurface import UnstructuredData
 from subsurface.api.reader.read_wells import read_wells
 from subsurface.core.geological_formats.boreholes.boreholes import BoreholeSet, MergeOptions
@@ -15,6 +14,7 @@ from subsurface.core.structs.unstructured_elements import PointSet
 from subsurface.modules.reader.wells.read_borehole_interface import read_collar, read_survey, read_lith, read_attributes
 from subsurface.modules.visualization import to_pyvista_points, pv_plot, to_pyvista_line, init_plotter
 from ._aux_func import _plot
+from ...conftest import RequirementsLevel
 
 dotenv.load_dotenv()
 

--- a/tests/test_io/test_lines/test_lines_I.py
+++ b/tests/test_io/test_lines/test_lines_I.py
@@ -144,7 +144,7 @@ def test_read_assay():
         scalar="Cu(%)_GDR",
         trajectory=borehole_set.combined_trajectory,
         collars=borehole_set.collars,
-        image_2d=False
+        image_2d=True
     )
 
 

--- a/tests/test_io/test_lines/test_lines_I.py
+++ b/tests/test_io/test_lines/test_lines_I.py
@@ -22,7 +22,7 @@ PLOT = True
 
 pytestmark = pytest.mark.skipif(
     condition=(RequirementsLevel.READ_WELL) not in RequirementsLevel.REQUIREMENT_LEVEL_TO_TEST(),
-    reason="Need to set the READ_MESH"
+    reason="Need to set the READ_WELL"
 )
 
 def test_read_collar():

--- a/tests/test_io/test_lines/test_lines_I.py
+++ b/tests/test_io/test_lines/test_lines_I.py
@@ -12,7 +12,7 @@ from subsurface.core.structs.base_structures.base_structures_enum import Special
 from subsurface.core.structs.unstructured_elements import PointSet
 from subsurface.modules.reader.wells.read_borehole_interface import read_collar, read_survey, read_lith, read_attributes
 from subsurface.modules.visualization import to_pyvista_points, pv_plot, to_pyvista_line, init_plotter
-from test_io.test_lines._aux_func import _plot
+from ._aux_func import _plot
 
 dotenv.load_dotenv()
 

--- a/tests/test_io/test_lines/test_lines_I.py
+++ b/tests/test_io/test_lines/test_lines_I.py
@@ -3,14 +3,16 @@ import os
 import pandas as pd
 
 from subsurface import UnstructuredData
+from subsurface.api.reader.read_wells import read_wells
 from subsurface.core.geological_formats.boreholes.boreholes import BoreholeSet, MergeOptions
 from subsurface.core.geological_formats.boreholes.collars import Collars
 from subsurface.core.geological_formats.boreholes.survey import Survey
 from subsurface.core.reader_helpers.readers_data import GenericReaderFilesHelper
 from subsurface.core.structs.base_structures.base_structures_enum import SpecialCellCase
 from subsurface.core.structs.unstructured_elements import PointSet
-from subsurface.modules.reader.wells.read_borehole_interface import read_collar, read_survey, read_lith
+from subsurface.modules.reader.wells.read_borehole_interface import read_collar, read_survey, read_lith, read_attributes
 from subsurface.modules.visualization import to_pyvista_points, pv_plot, to_pyvista_line, init_plotter
+from test_io.test_lines._aux_func import _plot
 
 dotenv.load_dotenv()
 
@@ -89,6 +91,56 @@ def test_add_auxiliary_fields_to_survey():
     data_set: xr.Dataset = data_array.data
 
     pass
+
+
+def test_read_assay():
+    reader_collar: GenericReaderFilesHelper = GenericReaderFilesHelper(
+        file_or_buffer=os.getenv("PATH_TO_SPREMBERG_COLLAR"),
+        header=0,
+        usecols=[0, 1, 2, 4],
+        columns_map={
+                "hole_id"            : "id",  # ? Index name is not mapped
+                "X_GK5_incl_inserted": "x",
+                "Y__incl_inserted"   : "y",
+                "Z_GK"               : "z"
+        }
+    )
+    reader: GenericReaderFilesHelper = GenericReaderFilesHelper(
+        file_or_buffer=os.getenv("PATH_TO_SPREMBERG_SURVEY"),
+        columns_map={
+                'depth'  : 'md',
+                'dip'    : 'dip',
+                'azimuth': 'azi'
+        },
+    )
+
+    reader_attr: GenericReaderFilesHelper = GenericReaderFilesHelper(
+        file_or_buffer=os.getenv("PATH_TO_SPREMBERG_ASSAY"),
+        columns_map={
+                'hole_id'   : 'id',
+                'depth_from': 'top',
+                'depth_to'  : 'base'
+        },
+        additional_reader_kwargs={
+                'na_values': [-9999]
+        }
+    )
+    
+    borehole_set: BoreholeSet = read_wells(
+        collars_reader=reader_collar,
+        surveys_reader=reader,
+        attrs_reader=reader_attr,
+        is_lith_attr=False,
+        add_attrs_as_nodes=True
+    )
+    
+    _plot(
+        scalar="Cu(%)_GDR",
+        trajectory=borehole_set.combined_trajectory,
+        collars=borehole_set.collars,
+        image_2d=False
+    )
+
 
 
 def test_read_stratigraphy():

--- a/tests/test_io/test_lines/test_lines_II.py
+++ b/tests/test_io/test_lines/test_lines_II.py
@@ -3,7 +3,7 @@ import os
 import pandas as pd
 import pytest
 import numpy as np
-from subsurface import UnstructuredData
+from subsurface.core.structs.base_structures import UnstructuredData
 from subsurface.core.geological_formats.boreholes.boreholes import BoreholeSet, MergeOptions
 from subsurface.core.geological_formats.boreholes.collars import Collars
 from subsurface.core.geological_formats.boreholes.survey import Survey

--- a/tests/test_io/test_lines/test_lines_II.py
+++ b/tests/test_io/test_lines/test_lines_II.py
@@ -3,6 +3,8 @@ import os
 import pandas as pd
 import pytest
 import numpy as np
+
+from conftest import RequirementsLevel
 from subsurface.core.structs.base_structures import UnstructuredData
 from subsurface.core.geological_formats.boreholes.boreholes import BoreholeSet, MergeOptions
 from subsurface.core.geological_formats.boreholes.collars import Collars
@@ -20,6 +22,10 @@ PLOT = True
 
 data_folder = os.getenv("PATH_TO_ASCII_DRILLHOLES")
 
+pytestmark = pytest.mark.skipif(
+    condition=(RequirementsLevel.READ_WELL) not in RequirementsLevel.REQUIREMENT_LEVEL_TO_TEST(),
+    reason="Need to set the READ_MESH"
+)
 
 @pytest.mark.liquid_earth
 def test_read_attr_into_borehole():

--- a/tests/test_io/test_lines/test_lines_II.py
+++ b/tests/test_io/test_lines/test_lines_II.py
@@ -4,7 +4,6 @@ import pandas as pd
 import pytest
 import numpy as np
 
-from conftest import RequirementsLevel
 from subsurface.core.structs.base_structures import UnstructuredData
 from subsurface.core.geological_formats.boreholes.boreholes import BoreholeSet, MergeOptions
 from subsurface.core.geological_formats.boreholes.collars import Collars
@@ -14,7 +13,8 @@ from subsurface.core.structs.base_structures.base_structures_enum import Special
 from subsurface.core.structs.unstructured_elements import PointSet
 from subsurface.modules.reader.wells.read_borehole_interface import read_collar, read_survey, read_lith, read_attributes
 from subsurface.modules.visualization import to_pyvista_points, pv_plot, to_pyvista_line
-from tests.test_io.test_lines._aux_func import _plot
+from ._aux_func import _plot
+from ...conftest import RequirementsLevel
 
 dotenv.load_dotenv()
 

--- a/tests/test_io/test_lines/test_lines_III.py
+++ b/tests/test_io/test_lines/test_lines_III.py
@@ -4,6 +4,7 @@ import pathlib
 
 import pytest
 
+from conftest import RequirementsLevel
 from subsurface import UnstructuredData
 from subsurface.core.geological_formats.boreholes.boreholes import BoreholeSet, MergeOptions
 from subsurface.core.geological_formats.boreholes.collars import Collars
@@ -21,6 +22,10 @@ PLOT = True
 pf = pathlib.Path(__file__).parent.absolute()
 data_path = pf.joinpath('../../data/borehole/')
 
+pytestmark = pytest.mark.skipif(
+    condition=(RequirementsLevel.READ_WELL) not in RequirementsLevel.REQUIREMENT_LEVEL_TO_TEST(),
+    reason="Need to set the READ_MESH"
+)
 
 @pytest.mark.liquid_earth
 def test_read_kim():

--- a/tests/test_io/test_lines/test_lines_III.py
+++ b/tests/test_io/test_lines/test_lines_III.py
@@ -4,7 +4,6 @@ import pathlib
 
 import pytest
 
-from conftest import RequirementsLevel
 from subsurface import UnstructuredData
 from subsurface.core.geological_formats.boreholes.boreholes import BoreholeSet, MergeOptions
 from subsurface.core.geological_formats.boreholes.collars import Collars
@@ -13,7 +12,8 @@ from subsurface.core.reader_helpers.readers_data import GenericReaderFilesHelper
 from subsurface.core.structs.base_structures.base_structures_enum import SpecialCellCase
 from subsurface.core.structs.unstructured_elements import PointSet
 from subsurface.modules.reader.wells.read_borehole_interface import read_collar, read_survey, read_lith
-from tests.test_io.test_lines._aux_func import _plot
+from ._aux_func import _plot
+from ...conftest import RequirementsLevel
 
 dotenv.load_dotenv()
 

--- a/tests/test_io/test_lines/test_lines_IV.py
+++ b/tests/test_io/test_lines/test_lines_IV.py
@@ -3,7 +3,6 @@ import os
 import pandas as pd
 import pytest
 
-from conftest import RequirementsLevel
 from subsurface.core.geological_formats.boreholes.boreholes import BoreholeSet, MergeOptions
 from subsurface.core.geological_formats.boreholes.collars import Collars
 from subsurface.core.geological_formats.boreholes.survey import Survey
@@ -11,7 +10,8 @@ from subsurface.core.reader_helpers.readers_data import GenericReaderFilesHelper
 from subsurface.core.structs.base_structures.base_structures_enum import SpecialCellCase
 from subsurface.modules.reader.wells.read_borehole_interface import read_collar, read_survey, read_lith
 import subsurface as ss
-from tests.test_io.test_lines._aux_func import _plot
+from ._aux_func import _plot
+from ...conftest import RequirementsLevel
 
 dotenv.load_dotenv()
 

--- a/tests/test_io/test_lines/test_lines_IV.py
+++ b/tests/test_io/test_lines/test_lines_IV.py
@@ -1,7 +1,9 @@
 import dotenv
 import os
 import pandas as pd
+import pytest
 
+from conftest import RequirementsLevel
 from subsurface.core.geological_formats.boreholes.boreholes import BoreholeSet, MergeOptions
 from subsurface.core.geological_formats.boreholes.collars import Collars
 from subsurface.core.geological_formats.boreholes.survey import Survey
@@ -17,6 +19,10 @@ PLOT = True
 
 data_folder = os.getenv("PATH_TO_BGR")
 
+pytestmark = pytest.mark.skipif(
+    condition=(RequirementsLevel.READ_WELL) not in RequirementsLevel.REQUIREMENT_LEVEL_TO_TEST(),
+    reason="Need to set the READ_MESH"
+)
 
 def test_read():
     raw_borehole_data_csv = data_folder + "boreholes_test.csv"

--- a/tests/test_io/test_meshes/test_glf.py
+++ b/tests/test_io/test_meshes/test_glf.py
@@ -37,6 +37,10 @@ def test_trimesh_read_glb_complex():
     return
 
 
+@pytest.mark.skipif(
+    condition=(RequirementsLevel.MESH | RequirementsLevel.PLOT) not in RequirementsLevel.REQUIREMENT_LEVEL_TO_TEST(),
+    reason="Need to set the READ_MESH variable to run this test"
+)
 def test_trimesh_read_glb():
     """
     Test loading a .glb (binary glTF) file with trimesh.

--- a/tests/test_io/test_meshes/test_read_obj.py
+++ b/tests/test_io/test_meshes/test_read_obj.py
@@ -17,7 +17,7 @@ path_to_mtl = os.getenv("PATH_TO_MTL")
 path_to_obj_no_material = os.getenv("PATH_TO_OBJ_GALLERIES_I")
 
 pytestmark = pytest.mark.skipif(
-    condition=(RequirementsLevel.READ_WELL) not in RequirementsLevel.REQUIREMENT_LEVEL_TO_TEST(),
+    condition=(RequirementsLevel.READ_MESH) not in RequirementsLevel.REQUIREMENT_LEVEL_TO_TEST(),
     reason="Need to set the READ_WELL"
 )
 

--- a/tests/test_io/test_meshes/test_read_obj.py
+++ b/tests/test_io/test_meshes/test_read_obj.py
@@ -8,6 +8,7 @@ from subsurface.modules.visualization import to_pyvista_mesh, pv_plot
 
 from subsurface import optional_requirements
 from subsurface.modules.reader.mesh._trimesh_reader import trimesh_to_unstruct, load_with_trimesh, TriMeshTransformations
+from ...conftest import RequirementsLevel
 
 dotenv.load_dotenv()
 
@@ -15,8 +16,10 @@ path_to_obj = os.getenv("PATH_TO_OBJ")
 path_to_mtl = os.getenv("PATH_TO_MTL")
 path_to_obj_no_material = os.getenv("PATH_TO_OBJ_GALLERIES_I")
 
-pytestmark = pytest.mark.read_mesh
-
+pytestmark = pytest.mark.skipif(
+    condition=(RequirementsLevel.READ_WELL) not in RequirementsLevel.REQUIREMENT_LEVEL_TO_TEST(),
+    reason="Need to set the READ_WELL"
+)
 
 def test_read_obj_mesh_no_materials():
     pv = optional_requirements.require_pyvista()

--- a/tests/test_io/test_meshes/test_read_profiles.py
+++ b/tests/test_io/test_meshes/test_read_profiles.py
@@ -56,6 +56,10 @@ def test_read_trace_to_unstruct(data_path):
     s, uv = to_pyvista_mesh_and_texture(ts)
     pv_plot([s], image_2d=True)
 
+@pytest.mark.skipif(
+    condition=(RequirementsLevel.READ_PROFILES) not in RequirementsLevel.REQUIREMENT_LEVEL_TO_TEST(),
+    reason="Need to set the READ_PROFILES flag to True in the conftest.py file to run this test"
+)
 def test_interpreted_profile():
     filepath = os.getenv("PATH_TO_INTERPRETATION")
 
@@ -134,6 +138,10 @@ def test_line_set_from_trace(data_path):
     pv_plot(m, image_2d=True)
 
 
+@pytest.mark.skipif(
+    condition=(RequirementsLevel.READ_PROFILES) not in RequirementsLevel.REQUIREMENT_LEVEL_TO_TEST(),
+    reason="Need to set the READ_PROFILES flag to True in the conftest.py file to run this test"
+)
 class TestSeismicProfiles:
     def test_interpreted_profile_seismics(self):
         filepath = os.getenv("PATH_TO_INTERPRETATION")

--- a/tests/test_io/test_volumes/test_read_volume.py
+++ b/tests/test_io/test_volumes/test_read_volume.py
@@ -15,7 +15,7 @@ pf = pathlib.Path(__file__).parent.absolute()
 data_path = pf.joinpath('../../data/volume/')
 
 pytestmark = pytest.mark.skipif(
-    condition=(RequirementsLevel.PLOT) not in RequirementsLevel.REQUIREMENT_LEVEL_TO_TEST(),
+    condition=(RequirementsLevel.READ_VOLUME) not in RequirementsLevel.REQUIREMENT_LEVEL_TO_TEST(),
     reason="Need to set the READ_MESH"
 )
 


### PR DESCRIPTION
### TL;DR

Added functionality to handle NaN values in borehole visualization and implemented a test for reading assay data.

### What changed?

- Created a new `clip_nan_points` function to filter out NaN values from point data in visualizations
- Added a test case `test_read_assay()` that demonstrates how to read and visualize assay data from boreholes
- Integrated the NaN filtering into the existing `_plot` function
- Added necessary imports including NumPy and the read_wells API function

### How to test?

1. Run the new `test_read_assay()` test which reads collar, survey, and assay data
2. Verify that the visualization correctly displays Cu(%) values without NaN-related errors
3. Check that the `clip_nan_points` function properly filters out points with NaN scalar values

### Why make this change?

Borehole data often contains measurement gaps or missing values (NaNs) which can cause visualization issues. This change improves the robustness of the visualization pipeline by properly handling these NaN values, ensuring that only valid data points are displayed. Additionally, the new test case provides an example of how to work with assay data, which is a common use case in subsurface analysis.