### PR TITLE
[ENH] Improve lithology handling in borehole data processing | GEN-10672

### DIFF
--- a/subsurface/core/geological_formats/boreholes/survey.py
+++ b/subsurface/core/geological_formats/boreholes/survey.py
@@ -114,6 +114,8 @@ def _map_attrs_to_measured_depths(attrs: pd.DataFrame, survey: Survey) -> pd.Dat
     if 'component lith' in attrs.columns and 'lith_ids' not in attrs.columns:
         # Factorize lith components directly in-place
         attrs['lith_ids'], _ = pd.factorize(attrs['component lith'], use_na_sentinel=True)
+    else:
+        pass
 
     # Add missing columns from attrs, preserving their dtypes
     for col in attrs.columns.difference(new_attrs.columns):
@@ -152,7 +154,7 @@ def _map_attrs_to_measured_depths(attrs: pd.DataFrame, survey: Survey) -> pd.Dat
                 continue
             attr_to_interpolate = attrs_well[col]
             # make sure the attr_to_interpolate is not a string
-            if attr_to_interpolate.dtype == 'O':
+            if attr_to_interpolate.dtype == 'O' or isinstance(attr_to_interpolate.dtype, pd.CategoricalDtype): 
                 continue
             if col in ['lith_ids', 'component lith']:
                 interp_kind = 'nearest'

--- a/subsurface/core/geological_formats/boreholes/survey.py
+++ b/subsurface/core/geological_formats/boreholes/survey.py
@@ -111,7 +111,7 @@ def _map_attrs_to_measured_depths(attrs: pd.DataFrame, survey: Survey) -> pd.Dat
 
     # Start with a copy of the existing attributes DataFrame
     new_attrs = survey.survey_trajectory.data.points_attributes.copy()
-    if 'component lith' in attrs.columns:
+    if 'component lith' in attrs.columns and 'lith_ids' not in attrs.columns:
         # Factorize lith components directly in-place
         attrs['lith_ids'], _ = pd.factorize(attrs['component lith'], use_na_sentinel=True)
 

--- a/subsurface/modules/reader/wells/read_borehole_interface.py
+++ b/subsurface/modules/reader/wells/read_borehole_interface.py
@@ -100,6 +100,16 @@ def _validate_lith_data(d: pd.DataFrame, reader_helper: GenericReaderFilesHelper
         raise AttributeError('If wells attributes represent lithology, `component lith` column must be present in the file. '
                              'Use columns_map to assign column names to these fields. Maybe you are marking as lithology'
                              'the wrong file?')
+    else:
+        # TODO: Add categories to reader helper
+        categories = sorted(d['component lith'].dropna().unique())
+        d['component lith'] = pd.Categorical(
+            d['component lith'],
+            categories=categories,
+            ordered=True
+        )
+        
+        d['lith_ids'] = d['component lith'].cat.codes + 1
 
     given_top = np.isin(['top', 'base'], d.columns).all()
     given_altitude_and_base = np.isin(['altitude', 'base'], d.columns).all()

--- a/tests/test_io/test_lines/test_lines_I.py
+++ b/tests/test_io/test_lines/test_lines_I.py
@@ -192,7 +192,7 @@ def test_read_stratigraphy():
     foo["well_name"] = foo["well_id"].map(well_id_mapper)
     
 
-    if PLOT and False:
+    if PLOT and True:
         trajectory = borehole_set.combined_trajectory
         s = to_pyvista_line(
             line_set=trajectory,


### PR DESCRIPTION
# Improved lithology attribute processing in borehole data handling

Updated the lithology processing workflow to ensure consistent handling of 'component lith' attributes by:

1. Adding a condition to check for existing 'lith_ids' before factorizing lithology components
2. Implementing categorical encoding for 'component lith' values in the borehole reader interface
3. Assigning proper lithology IDs with offset (+1) to maintain consistent numbering

These changes improve the robustness of the lithology data processing pipeline and ensure consistent behavior when working with borehole data that may have different attribute structures.