### PR TITLE
[FIX] Update transformation matrix in trimesh reader | GEN-11914

### DIFF
--- a/subsurface/modules/reader/mesh/_trimesh_reader.py
+++ b/subsurface/modules/reader/mesh/_trimesh_reader.py
@@ -37,9 +37,9 @@ def load_with_trimesh(path_to_file_or_buffer, file_type: Optional[str] = None,
             # Old Z axis → New -Y axis
             # Old X axis → Remains as X axis
             transform = np.array([
-                    [1, 0, 0, 0],  # X → X
-                    [0, 0, 1, 0],  # Y → Z 
-                    [0, 1, 0, 0],  # Z → -Y
+                    [-1, 0, 0, 0],  
+                    [0, 0, 1, 0],  
+                    [0, 1, 0, 0], 
                     [0, 0, 0, 1]
             ])
 


### PR DESCRIPTION
|### TL;DR

Updated the transformation matrix in the trimesh reader to flip the X-axis.

### What changed?

Modified the transformation matrix in `_trimesh_reader.py` by changing the first row from `[1, 0, 0, 0]` to `[-1, 0, 0, 0]`. This effectively flips the X-axis during mesh loading.

### How to test?

1. Load a 3D mesh file using the `load_with_trimesh` function
2. Verify that the mesh is correctly oriented with the X-axis flipped
3. Compare with previous results to confirm the change in orientation

### Why make this change?

This change corrects the coordinate system transformation when loading meshes with trimesh. The previous transformation preserved the X-axis, but the correct behavior requires flipping the X-axis to properly align with the target coordinate system.