### PR TITLE
[ENH] Add Grav3D mesh and model file reader | GEN-11485

### DIFF
--- a/subsurface/core/structs/structured_elements/structured_grid.py
+++ b/subsurface/core/structs/structured_elements/structured_grid.py
@@ -33,6 +33,10 @@ class StructuredGrid:
         grid_3d = np.meshgrid(*cart_coord, indexing='ij')
         return grid_3d
 
+    @property
+    def active_attributes(self) -> np.ndarray:
+        return self.ds.data[self.ds.active_data_array_name].values
+
     def meshgrid_2d(self, attribute_name_coord_name: str = None) -> list:
         """
 

--- a/subsurface/modules/reader/volume/read_grav3d.py
+++ b/subsurface/modules/reader/volume/read_grav3d.py
@@ -1,219 +1,401 @@
-﻿from dataclasses import dataclass
-from typing import List
+﻿from dataclasses import dataclass, field
+from typing import List, Dict, Any, Tuple, Optional, Union
 import numpy as np
+import xarray as xr
+from pathlib import Path
 
 from ....core.structs import StructuredData
 
 
 @dataclass
-class Dimensions:
-    ne: int
-    nn: int
+class GridDimensions:
+    """
+    Represents the dimensions of a 3D grid.
+
+    Attributes:
+        nx (int): Number of cells in the x-direction
+        ny (int): Number of cells in the y-direction
+        nz (int): Number of cells in the z-direction
+    """
+    nx: int
+    ny: int
     nz: int
 
+    @property
+    def ne(self) -> int:
+        """Legacy accessor for nx (easting)"""
+        return self.nx
 
-@dataclass
-class Origin:
-    x0: float
-    y0: float
-    z0: float
-
-
-@dataclass
-class CellSizes:
-    easting: List[float]
-    northing: List[float]
-    vertical: List[float]
+    @property
+    def nn(self) -> int:
+        """Legacy accessor for ny (northing)"""
+        return self.ny
 
 
 @dataclass
-class MeshData:
-    dimensions: Dimensions
-    origin: Origin
-    cell_sizes: CellSizes
+class GridOrigin:
+    """
+    Represents the origin point of a 3D grid.
+
+    Attributes:
+        x (float): X-coordinate of the origin
+        y (float): Y-coordinate of the origin
+        z (float): Z-coordinate of the origin
+    """
+    x: float
+    y: float
+    z: float
+
+    @property
+    def x0(self) -> float:
+        """Legacy accessor for x"""
+        return self.x
+
+    @property
+    def y0(self) -> float:
+        """Legacy accessor for y"""
+        return self.y
+
+    @property
+    def z0(self) -> float:
+        """Legacy accessor for z"""
+        return self.z
+
+
+@dataclass
+class GridCellSizes:
+    """
+    Represents the cell sizes in each direction of a 3D grid.
+
+    Attributes:
+        x (List[float]): Cell sizes in the x-direction
+        y (List[float]): Cell sizes in the y-direction
+        z (List[float]): Cell sizes in the z-direction
+    """
+    x: List[float]
+    y: List[float]
+    z: List[float]
+
+    @property
+    def easting(self) -> List[float]:
+        """Legacy accessor for x"""
+        return self.x
+
+    @property
+    def northing(self) -> List[float]:
+        """Legacy accessor for y"""
+        return self.y
+
+    @property
+    def vertical(self) -> List[float]:
+        """Legacy accessor for z"""
+        return self.z
+
+
+@dataclass
+class GridData:
+    """
+    Represents a 3D grid with dimensions, origin, and cell sizes.
+
+    Attributes:
+        dimensions (GridDimensions): The dimensions of the grid
+        origin (GridOrigin): The origin point of the grid
+        cell_sizes (GridCellSizes): The cell sizes in each direction
+        metadata (Dict[str, Any]): Optional metadata about the grid
+    """
+    dimensions: GridDimensions
+    origin: GridOrigin
+    cell_sizes: GridCellSizes
+    metadata: Dict[str, Any] = field(default_factory=dict)
 
     @classmethod
-    def from_dict(cls, mesh_dict):
+    def from_dict(cls, grid_dict: Dict[str, Any]) -> 'GridData':
         """
-        Converts a dictionary containing mesh information into a MeshData data class.
-        """
-        dims = mesh_dict["dimensions"]
-        origin_dict = mesh_dict["origin"]
-        cell_sizes_dict = mesh_dict["cell_sizes"]
+        Converts a dictionary containing grid information into a GridData instance.
 
-        return MeshData(
-            dimensions=Dimensions(ne=dims["ne"], nn=dims["nn"], nz=dims["nz"]),
-            origin=Origin(x0=origin_dict["x0"], y0=origin_dict["y0"], z0=origin_dict["z0"]),
-            cell_sizes=CellSizes(
-                easting=cell_sizes_dict["easting"],
-                northing=cell_sizes_dict["northing"],
-                vertical=cell_sizes_dict["vertical"]
-            )
+        Args:
+            grid_dict: Dictionary with grid information
+
+        Returns:
+            GridData: A new GridData instance
+        """
+        dims = grid_dict["dimensions"]
+        origin_dict = grid_dict["origin"]
+        cell_sizes_dict = grid_dict["cell_sizes"]
+
+        # Handle both new and legacy key names
+        nx = dims.get("nx", dims.get("ne"))
+        ny = dims.get("ny", dims.get("nn"))
+        nz = dims.get("nz", dims.get("nz"))
+
+        x = origin_dict.get("x", origin_dict.get("x0"))
+        y = origin_dict.get("y", origin_dict.get("y0"))
+        z = origin_dict.get("z", origin_dict.get("z0"))
+
+        x_sizes = cell_sizes_dict.get("x", cell_sizes_dict.get("easting"))
+        y_sizes = cell_sizes_dict.get("y", cell_sizes_dict.get("northing"))
+        z_sizes = cell_sizes_dict.get("z", cell_sizes_dict.get("vertical"))
+
+        metadata = grid_dict.get("metadata", {})
+
+        return cls(
+            dimensions=GridDimensions(nx=nx, ny=ny, nz=nz),
+            origin=GridOrigin(x=x, y=y, z=z),
+            cell_sizes=GridCellSizes(x=x_sizes, y=y_sizes, z=z_sizes),
+            metadata=metadata
         )
 
 
-def read_msh_file(filepath) -> MeshData:
+# For backward compatibility
+MeshData = GridData
+Dimensions = GridDimensions
+Origin = GridOrigin
+CellSizes = GridCellSizes
+
+
+def parse_cell_sizes(lines: List[str], start_index: int, count: int) -> Tuple[List[float], int]:
     """
-    Read a Grav3D mesh file (.msh) and return its contents as a structured dictionary.
+    Parse cell sizes from file lines, handling both compact (N*value) and expanded notation.
 
-    The mesh file format is:
-    - First line: NE NN NZ (number of cells in East, North, Vertical directions)
-    - Second line: X0 Y0 Z0 (coordinates of southwest top corner in meters)
-    - Next section: East cell widths (either expanded or using N*value notation)
-    - Next section: North cell widths (either expanded or using N*value notation)
-    - Next section: Vertical cell thicknesses (either expanded or using N*value notation)
-
-    Parameters:
-    -----------
-    filepath : str or Path
-        Path to the .msh file
+    Args:
+        lines: List of lines from the file
+        start_index: Index to start parsing from
+        count: Number of values to parse
 
     Returns:
-    --------
-    dict
-        Dictionary containing the mesh information
+        Tuple containing:
+            - List of parsed values
+            - Next line index after parsing
     """
+    line = lines[start_index]
+
+    # Check for compact notation (N*value)
+    if '*' in line:
+        parts = line.split('*')
+        repetition = int(parts[0])
+        value = float(parts[1])
+        values = [value] * repetition
+        return values, start_index + 1
+
+    # Handle expanded notation across multiple lines
+    values = []
+    line_index = start_index
+
+    while len(values) < count and line_index < len(lines):
+        current_line = lines[line_index]
+
+        # If we encounter a line with compact notation while parsing expanded, 
+        # it's likely the next section
+        if '*' in current_line and len(values) > 0:
+            break
+
+        # Add all numbers from the current line
+        values.extend([float(x) for x in current_line.split()])
+        line_index += 1
+
+    # Take only the required number of values
+    return values[:count], line_index
+
+
+def read_msh_file(filepath: Union[str, Path]) -> GridData:
+    """
+    Read a structured grid mesh file and return a GridData object.
+
+    Currently supports Grav3D mesh file format (.msh):
+    - First line: NX NY NZ (number of cells in X, Y, Z directions)
+    - Second line: X Y Z (coordinates of origin in meters)
+    - Next section: X cell widths (either expanded or using N*value notation)
+    - Next section: Y cell widths (either expanded or using N*value notation)
+    - Next section: Z cell thicknesses (either expanded or using N*value notation)
+
+    Args:
+        filepath: Path to the mesh file
+
+    Returns:
+        GridData object containing the mesh information
+
+    Raises:
+        FileNotFoundError: If the file doesn't exist
+        ValueError: If the file format is invalid
+    """
+    filepath = Path(filepath)
+    if not filepath.exists():
+        raise FileNotFoundError(f"Mesh file not found: {filepath}")
 
     with open(filepath, 'r') as f:
         lines = [line.strip() for line in f.readlines() if line.strip()]
 
+    if len(lines) < 2:
+        raise ValueError(f"Invalid mesh file format: {filepath}")
+
     # Parse dimensions (first line)
-    dims = lines[0].split()
-    ne, nn, nz = int(dims[0]), int(dims[1]), int(dims[2])
+    try:
+        dims = lines[0].split()
+        nx, ny, nz = int(dims[0]), int(dims[1]), int(dims[2])
+    except (IndexError, ValueError) as e:
+        raise ValueError(f"Invalid dimensions in mesh file: {e}")
 
     # Parse origin coordinates (second line)
-    origin = lines[1].split()
-    x0, y0, z0 = float(origin[0]), float(origin[1]), float(origin[2])
+    try:
+        origin = lines[1].split()
+        x, y, z = float(origin[0]), float(origin[1]), float(origin[2])
+    except (IndexError, ValueError) as e:
+        raise ValueError(f"Invalid origin in mesh file: {e}")
 
-    # Helper function to parse cell sizes with different notations
-    def parse_cell_sizes(start_index, count):
-        line = lines[start_index]
-
-        # Check for compact notation (N*value)
-        if '*' in line:
-            parts = line.split('*')
-            repetition = int(parts[0])
-            value = float(parts[1])
-            values = [value] * repetition
-            return values, start_index + 1
-
-        # Handle expanded notation across multiple lines
-        values = []
-        line_index = start_index
-
-        while len(values) < count and line_index < len(lines):
-            current_line = lines[line_index]
-
-            # If we encounter a line with compact notation while parsing expanded, 
-            # it's likely the next section
-            if '*' in current_line and len(values) > 0:
-                break
-
-            # Add all numbers from the current line
-            values.extend([float(x) for x in current_line.split()])
-            line_index += 1
-
-        # Take only the required number of values
-        return values[:count], line_index
-
-    # Parse easting cell widths
-    current_line = 2
-    e_widths, current_line = parse_cell_sizes(current_line, ne)
-
-    # Parse northing cell widths
-    n_widths, current_line = parse_cell_sizes(current_line, nn)
-
-    # Parse vertical cell thicknesses
-    z_thicknesses, _ = parse_cell_sizes(current_line, nz)
+    # Parse cell sizes
+    try:
+        current_line = 2
+        x_sizes, current_line = parse_cell_sizes(lines, current_line, nx)
+        y_sizes, current_line = parse_cell_sizes(lines, current_line, ny)
+        z_sizes, _ = parse_cell_sizes(lines, current_line, nz)
+    except (IndexError, ValueError) as e:
+        raise ValueError(f"Error parsing cell sizes: {e}")
 
     # Create a dictionary with all the parsed information
-    mesh_data_dict = {
-            'dimensions': {'ne': ne, 'nn': nn, 'nz': nz},
-            'origin'    : {'x0': x0, 'y0': y0, 'z0': z0},
-            'cell_sizes': {
-                    'easting' : e_widths,
-                    'northing': n_widths,
-                    'vertical': z_thicknesses
-            }
+    grid_data_dict = {
+        'dimensions': {'nx': nx, 'ny': ny, 'nz': nz},
+        'origin': {'x': x, 'y': y, 'z': z},
+        'cell_sizes': {
+            'x': x_sizes,
+            'y': y_sizes,
+            'z': z_sizes
+        },
+        'metadata': {
+            'file_format': 'grav3d',
+            'filepath': str(filepath)
+        }
     }
 
-    mesh_data = MeshData.from_dict(mesh_data_dict)
-
-    return mesh_data
+    return GridData.from_dict(grid_data_dict)
 
 
-def structured_data_from(array: np.ndarray, mesh: MeshData) -> StructuredData:
-    easting = np.array(mesh.cell_sizes.easting)
-    x_centers = mesh.origin.x0 + np.cumsum(easting) - easting[0] / 2
-    # For northing, start from origin.y0
-    northing = np.array(mesh.cell_sizes.northing)
-    y_centers = mesh.origin.y0 + np.cumsum(northing) - northing[0] / 2
-    # For vertical, note that the top is given by origin.z0 and cells extend downward.
-    vertical = np.array(mesh.cell_sizes.vertical)
-    z_centers = mesh.origin.z0 - (np.cumsum(vertical) - vertical[0] / 2)
-    # Create the DataArray.
-    # The array shape is (nn, ne, nz). We use dimension names 'north', 'east' and 'vertical'
-    import xarray as xr
+def calculate_cell_centers(grid: GridData) -> Dict[str, np.ndarray]:
+    """
+    Calculate the center coordinates of each cell in the grid.
+
+    Args:
+        grid: GridData object containing grid dimensions, origin, and cell sizes
+
+    Returns:
+        Dictionary with 'x', 'y', and 'z' keys containing arrays of cell center coordinates
+    """
+    # Convert cell sizes to numpy arrays for vectorized operations
+    x_sizes = np.array(grid.cell_sizes.x)
+    y_sizes = np.array(grid.cell_sizes.y)
+    z_sizes = np.array(grid.cell_sizes.z)
+
+    # Calculate cell centers by adding cumulative sizes and offsetting by half the first cell size
+    x_centers = grid.origin.x + np.cumsum(x_sizes) - x_sizes[0] / 2
+    y_centers = grid.origin.y + np.cumsum(y_sizes) - y_sizes[0] / 2
+
+    # For z, cells typically extend downward from the origin
+    z_centers = grid.origin.z - (np.cumsum(z_sizes) - z_sizes[0] / 2)
+
+    return {
+        'x': x_centers,
+        'y': y_centers,
+        'z': z_centers
+    }
+
+
+def structured_data_from(array: np.ndarray, grid: GridData, 
+                         data_name: str = 'model') -> StructuredData:
+    """
+    Convert a 3D numpy array and grid information into a StructuredData object.
+
+    Args:
+        array: 3D numpy array of property values with shape (ny, nx, nz)
+        grid: GridData object containing grid dimensions, origin, and cell sizes
+        data_name: Name for the data array (default: 'model')
+
+    Returns:
+        StructuredData object containing the data array with proper coordinates
+
+    Raises:
+        ValueError: If array shape doesn't match grid dimensions
+    """
+    # Verify array shape matches grid dimensions
+    expected_shape = (grid.dimensions.ny, grid.dimensions.nx, grid.dimensions.nz)
+    if array.shape != expected_shape:
+        raise ValueError(
+            f"Array shape {array.shape} doesn't match grid dimensions {expected_shape}"
+        )
+
+    # Calculate cell center coordinates
+    centers = calculate_cell_centers(grid)
+
+    # Create the xarray DataArray with proper coordinates
     xr_data_array = xr.DataArray(
         data=array,
-        dims=['x', 'y', 'z'],
+        dims=['y', 'x', 'z'],  # Dimensions in the order they appear in the array
         coords={
-                'x': y_centers,
-                'y': x_centers,
-                'z': z_centers,
+            'x': centers['x'],
+            'y': centers['y'],
+            'z': centers['z'],
         },
-        name='model'
+        name=data_name,
+        attrs=grid.metadata  # Include grid metadata in the data array
     )
-    # Optionally, wrap the xr.DataArray into a StructuredData instance
-    struct: StructuredData = StructuredData.from_data_array(
+
+    # Create a StructuredData instance from the xarray DataArray
+    struct = StructuredData.from_data_array(
         data_array=xr_data_array,
-        data_array_name='model'
+        data_array_name=data_name
     )
+
     return struct
 
-def read_mod_file(filepath: str, mesh: MeshData) -> np.ndarray:
+def read_mod_file(filepath: Union[str, Path], grid: GridData, 
+               missing_value: float = -99_999.0) -> np.ndarray:
     """
-    Reads a Grav3D model file (.mod) and validates its shape against the provided mesh.
-    
-    The file should contain NN * NE * NZ lines where each line is a cell property value.
-    The values are in the order:
-      - First in the z-direction (top-to-bottom)
-      - Then in the easting
-      - Finally in the northing
-    This function reshapes the data into an array of shape (NN, NE, NZ) using row-major order.
-    
-    Parameters:
-    -----------
-    filepath : str
-        Path to the .mod file.
-    mesh : MeshData
-        Mesh information with dimensions (ne, nn, nz).
-    
+    Read a model file containing property values for a 3D grid.
+
+    Currently supports Grav3D model file format (.mod) where each line contains
+    a single property value. The values are ordered with the z-direction changing
+    fastest, then x, then y.
+
+    Args:
+        filepath: Path to the model file
+        grid: GridData object containing the grid dimensions
+        missing_value: Value to replace with NaN in the output array (default: -99_999.0)
+
     Returns:
-    --------
-    np.ndarray
-        Three-dimensional array of model values with shape (nn, ne, nz).
-    
+        3D numpy array of property values with shape (ny, nx, nz)
+
     Raises:
-    -------
-    ValueError
-        If the total number of values does not equal NN * NE * NZ.
+        FileNotFoundError: If the file doesn't exist
+        ValueError: If the number of values doesn't match the grid dimensions
     """
-    with open(filepath, 'r') as f:
-        lines = [line.strip() for line in f if line.strip()]
-    
-    # Convert each line to a float
-    values = [float(line) for line in lines]
-    
-    # Expected total number of values using mesh dimensions. Note that mesh.dimensions is stored as (ne, nn, nz)
-    expected_count = mesh.dimensions.nn * mesh.dimensions.ne * mesh.dimensions.nz
-    if len(values) != expected_count:
-        raise ValueError(f"Invalid .mod file: expected {expected_count} values, got {len(values)}")
-    
-    # Reshape to (nn, ne, nz) so that the fastest changing axis is the vertical (z-direction)
-    model_array = np.array(values, dtype=float).reshape(
-        (mesh.dimensions.nn, mesh.dimensions.ne, mesh.dimensions.nz)
-    )
-    
-    model_array[model_array == -99_999.0] = np.nan
-    return model_array
+    filepath = Path(filepath)
+    if not filepath.exists():
+        raise FileNotFoundError(f"Model file not found: {filepath}")
+
+    try:
+        # Read all values from the file
+        with open(filepath, 'r') as f:
+            lines = [line.strip() for line in f if line.strip()]
+
+        # Convert each line to a float
+        values = np.array([float(line) for line in lines], dtype=float)
+
+        # Calculate expected number of values based on grid dimensions
+        nx, ny, nz = grid.dimensions.nx, grid.dimensions.ny, grid.dimensions.nz
+        expected_count = nx * ny * nz
+
+        if len(values) != expected_count:
+            raise ValueError(
+                f"Invalid model file: expected {expected_count} values, got {len(values)}"
+            )
+
+        # Reshape to (ny, nx, nz) with z changing fastest
+        model_array = values.reshape((ny, nx, nz))
+
+        # Replace missing values with NaN
+        if missing_value is not None:
+            model_array[model_array == missing_value] = np.nan
+
+        return model_array
+
+    except Exception as e:
+        # Add context to any errors
+        raise ValueError(f"Error reading model file {filepath}: {str(e)}") from e

--- a/subsurface/modules/reader/volume/read_grav3d.py
+++ b/subsurface/modules/reader/volume/read_grav3d.py
@@ -21,16 +21,6 @@ class GridDimensions:
     ny: int
     nz: int
 
-    @property
-    def ne(self) -> int:
-        """Legacy accessor for nx (easting)"""
-        return self.nx
-
-    @property
-    def nn(self) -> int:
-        """Legacy accessor for ny (northing)"""
-        return self.ny
-
 
 @dataclass
 class GridOrigin:
@@ -46,21 +36,6 @@ class GridOrigin:
     y: float
     z: float
 
-    @property
-    def x0(self) -> float:
-        """Legacy accessor for x"""
-        return self.x
-
-    @property
-    def y0(self) -> float:
-        """Legacy accessor for y"""
-        return self.y
-
-    @property
-    def z0(self) -> float:
-        """Legacy accessor for z"""
-        return self.z
-
 
 @dataclass
 class GridCellSizes:
@@ -75,21 +50,6 @@ class GridCellSizes:
     x: List[float]
     y: List[float]
     z: List[float]
-
-    @property
-    def easting(self) -> List[float]:
-        """Legacy accessor for x"""
-        return self.x
-
-    @property
-    def northing(self) -> List[float]:
-        """Legacy accessor for y"""
-        return self.y
-
-    @property
-    def vertical(self) -> List[float]:
-        """Legacy accessor for z"""
-        return self.z
 
 
 @dataclass
@@ -144,13 +104,6 @@ class GridData:
             cell_sizes=GridCellSizes(x=x_sizes, y=y_sizes, z=z_sizes),
             metadata=metadata
         )
-
-
-# For backward compatibility
-MeshData = GridData
-Dimensions = GridDimensions
-Origin = GridOrigin
-CellSizes = GridCellSizes
 
 
 def parse_cell_sizes(lines: List[str], start_index: int, count: int) -> Tuple[List[float], int]:
@@ -253,17 +206,17 @@ def read_msh_file(filepath: Union[str, Path]) -> GridData:
 
     # Create a dictionary with all the parsed information
     grid_data_dict = {
-        'dimensions': {'nx': nx, 'ny': ny, 'nz': nz},
-        'origin': {'x': x, 'y': y, 'z': z},
-        'cell_sizes': {
-            'x': x_sizes,
-            'y': y_sizes,
-            'z': z_sizes
-        },
-        'metadata': {
-            'file_format': 'grav3d',
-            'filepath': str(filepath)
-        }
+            'dimensions': {'nx': nx, 'ny': ny, 'nz': nz},
+            'origin'    : {'x': x, 'y': y, 'z': z},
+            'cell_sizes': {
+                    'x': x_sizes,
+                    'y': y_sizes,
+                    'z': z_sizes
+            },
+            'metadata'  : {
+                    'file_format': 'grav3d',
+                    'filepath'   : str(filepath)
+            }
     }
 
     return GridData.from_dict(grid_data_dict)
@@ -292,13 +245,13 @@ def calculate_cell_centers(grid: GridData) -> Dict[str, np.ndarray]:
     z_centers = grid.origin.z - (np.cumsum(z_sizes) - z_sizes[0] / 2)
 
     return {
-        'x': x_centers,
-        'y': y_centers,
-        'z': z_centers
+            'x': x_centers,
+            'y': y_centers,
+            'z': z_centers
     }
 
 
-def structured_data_from(array: np.ndarray, grid: GridData, 
+def structured_data_from(array: np.ndarray, grid: GridData,
                          data_name: str = 'model') -> StructuredData:
     """
     Convert a 3D numpy array and grid information into a StructuredData object.
@@ -329,9 +282,9 @@ def structured_data_from(array: np.ndarray, grid: GridData,
         data=array,
         dims=['y', 'x', 'z'],  # Dimensions in the order they appear in the array
         coords={
-            'x': centers['x'],
-            'y': centers['y'],
-            'z': centers['z'],
+                'x': centers['x'],
+                'y': centers['y'],
+                'z': centers['z'],
         },
         name=data_name,
         attrs=grid.metadata  # Include grid metadata in the data array
@@ -345,8 +298,9 @@ def structured_data_from(array: np.ndarray, grid: GridData,
 
     return struct
 
-def read_mod_file(filepath: Union[str, Path], grid: GridData, 
-               missing_value: float = -99_999.0) -> np.ndarray:
+
+def read_mod_file(filepath: Union[str, Path], grid: GridData,
+                  missing_value: float = -99_999.0) -> np.ndarray:
     """
     Read a model file containing property values for a 3D grid.
 

--- a/subsurface/modules/reader/volume/read_grav3d.py
+++ b/subsurface/modules/reader/volume/read_grav3d.py
@@ -1,0 +1,196 @@
+﻿from dataclasses import dataclass
+from typing import List
+
+
+@dataclass
+class Dimensions:
+    ne: int
+    nn: int
+    nz: int
+
+
+@dataclass
+class Origin:
+    x0: float
+    y0: float
+    z0: float
+
+
+@dataclass
+class CellSizes:
+    easting: List[float]
+    northing: List[float]
+    vertical: List[float]
+
+
+@dataclass
+class MeshData:
+    dimensions: Dimensions
+    origin: Origin
+    cell_sizes: CellSizes
+
+    @classmethod
+    def from_dict(cls, mesh_dict):
+        """
+        Converts a dictionary containing mesh information into a MeshData data class.
+        """
+        dims = mesh_dict["dimensions"]
+        origin_dict = mesh_dict["origin"]
+        cell_sizes_dict = mesh_dict["cell_sizes"]
+
+        return MeshData(
+            dimensions=Dimensions(ne=dims["ne"], nn=dims["nn"], nz=dims["nz"]),
+            origin=Origin(x0=origin_dict["x0"], y0=origin_dict["y0"], z0=origin_dict["z0"]),
+            cell_sizes=CellSizes(
+                easting=cell_sizes_dict["easting"],
+                northing=cell_sizes_dict["northing"],
+                vertical=cell_sizes_dict["vertical"]
+            )
+        )
+
+
+def read_msh_file(filepath) -> MeshData:
+    """
+    Read a Grav3D mesh file (.msh) and return its contents as a structured dictionary.
+
+    The mesh file format is:
+    - First line: NE NN NZ (number of cells in East, North, Vertical directions)
+    - Second line: X0 Y0 Z0 (coordinates of southwest top corner in meters)
+    - Next section: East cell widths (either expanded or using N*value notation)
+    - Next section: North cell widths (either expanded or using N*value notation)
+    - Next section: Vertical cell thicknesses (either expanded or using N*value notation)
+
+    Parameters:
+    -----------
+    filepath : str or Path
+        Path to the .msh file
+
+    Returns:
+    --------
+    dict
+        Dictionary containing the mesh information
+    """
+
+    """
+    This is in the msh file
+    100 139 46
+    313375 6072925 400
+    25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25
+    25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25
+    25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 
+    """
+    with open(filepath, 'r') as f:
+        lines = [line.strip() for line in f.readlines() if line.strip()]
+
+    # Parse dimensions (first line)
+    dims = lines[0].split()
+    ne, nn, nz = int(dims[0]), int(dims[1]), int(dims[2])
+
+    # Parse origin coordinates (second line)
+    origin = lines[1].split()
+    x0, y0, z0 = float(origin[0]), float(origin[1]), float(origin[2])
+
+    # Helper function to parse cell sizes with different notations
+    def parse_cell_sizes(start_index, count):
+        line = lines[start_index]
+
+        # Check for compact notation (N*value)
+        if '*' in line:
+            parts = line.split('*')
+            repetition = int(parts[0])
+            value = float(parts[1])
+            values = [value] * repetition
+            return values, start_index + 1
+
+        # Handle expanded notation across multiple lines
+        values = []
+        line_index = start_index
+
+        while len(values) < count and line_index < len(lines):
+            current_line = lines[line_index]
+
+            # If we encounter a line with compact notation while parsing expanded, 
+            # it's likely the next section
+            if '*' in current_line and len(values) > 0:
+                break
+
+            # Add all numbers from the current line
+            values.extend([float(x) for x in current_line.split()])
+            line_index += 1
+
+        # Take only the required number of values
+        return values[:count], line_index
+
+    # Parse easting cell widths
+    current_line = 2
+    e_widths, current_line = parse_cell_sizes(current_line, ne)
+
+    # Parse northing cell widths
+    n_widths, current_line = parse_cell_sizes(current_line, nn)
+
+    # Parse vertical cell thicknesses
+    z_thicknesses, _ = parse_cell_sizes(current_line, nz)
+
+    # Create a dictionary with all the parsed information
+    mesh_data_dict = {
+            'dimensions': {'ne': ne, 'nn': nn, 'nz': nz},
+            'origin'    : {'x0': x0, 'y0': y0, 'z0': z0},
+            'cell_sizes': {
+                    'easting' : e_widths,
+                    'northing': n_widths,
+                    'vertical': z_thicknesses
+            }
+    }
+
+    mesh_data = MeshData.from_dict(mesh_data_dict)
+
+    return mesh_data
+import numpy as np
+
+def read_mod_file(filepath: str, mesh: MeshData) -> np.ndarray:
+    """
+    Reads a Grav3D model file (.mod) and validates its shape against the provided mesh.
+    
+    The file should contain NN * NE * NZ lines where each line is a cell property value.
+    The values are in the order:
+      - First in the z-direction (top-to-bottom)
+      - Then in the easting
+      - Finally in the northing
+    This function reshapes the data into an array of shape (NN, NE, NZ) using row-major order.
+    
+    Parameters:
+    -----------
+    filepath : str
+        Path to the .mod file.
+    mesh : MeshData
+        Mesh information with dimensions (ne, nn, nz).
+    
+    Returns:
+    --------
+    np.ndarray
+        Three-dimensional array of model values with shape (nn, ne, nz).
+    
+    Raises:
+    -------
+    ValueError
+        If the total number of values does not equal NN * NE * NZ.
+    """
+    with open(filepath, 'r') as f:
+        lines = [line.strip() for line in f if line.strip()]
+    
+    # Convert each line to a float
+    values = [float(line) for line in lines]
+    
+    # Expected total number of values using mesh dimensions. Note that mesh.dimensions is stored as (ne, nn, nz)
+    expected_count = mesh.dimensions.nn * mesh.dimensions.ne * mesh.dimensions.nz
+    if len(values) != expected_count:
+        raise ValueError(f"Invalid .mod file: expected {expected_count} values, got {len(values)}")
+    
+    # Reshape to (nn, ne, nz) so that the fastest changing axis is the vertical (z-direction)
+    model_array = np.array(values, dtype=float).reshape(
+        (mesh.dimensions.nn, mesh.dimensions.ne, mesh.dimensions.nz)
+    )
+    
+    # -9999 to nan
+    model_array[model_array == -99_999.0] = np.nan
+    return model_array

--- a/tests/test_io/test_volumes/test_import_grav3d.py
+++ b/tests/test_io/test_volumes/test_import_grav3d.py
@@ -10,7 +10,7 @@ from subsurface import StructuredGrid
 from subsurface.modules.reader.volume.read_grav3d import (
     GridData, read_msh_file, read_mod_file, structured_data_from
 )
-from subsurface.modules.visualization import init_plotter
+from subsurface.modules.visualization import init_plotter, pyvista_to_matplotlib
 
 dotenv.load_dotenv()
 
@@ -42,14 +42,19 @@ def test_import_grav3d():
     sg: subsurface.StructuredGrid = StructuredGrid(struct)
 
     # Visualize the grid
-    p = init_plotter(image_2d=False, ve=1, plotter_kwargs=None)
+
+    image_2d = True
+    p = init_plotter(image_2d=image_2d, ve=1, plotter_kwargs=None)
     p.add_volume(
         sg.active_attributes,
         opacity='linear'
     )
     p.add_axes()
     p.add_bounding_box()
-    p.show()
+    if image_2d is False:
+        p.show()
+    else:
+        pyvista_to_matplotlib(p)
 
 
 def test_import_grav3d_II():
@@ -86,14 +91,20 @@ def test_import_grav3d_II():
     sg: subsurface.StructuredGrid = StructuredGrid(struct)
 
     # Visualize the grid
-    p = init_plotter(image_2d=False, ve=1, plotter_kwargs=None)
+    image_2d = True
+    p = init_plotter(image_2d=image_2d, ve=1, plotter_kwargs=None)
     p.add_volume(
         sg.active_attributes,
         opacity='linear'
     )
     p.add_axes()
     p.add_bounding_box()
-    p.show()
+    image_2d = True
+    if image_2d is False:
+        p.show()
+    else:
+        pyvista_to_matplotlib(p)
+
 
 
 def test_import_grav3d_III():
@@ -125,11 +136,19 @@ def test_import_grav3d_III():
     sg: subsurface.StructuredGrid = StructuredGrid(struct)
 
     # Visualize the grid
-    p = init_plotter(image_2d=False, ve=1, plotter_kwargs=None)
+    image_2d = True
+    p = init_plotter(image_2d=image_2d, ve=1, plotter_kwargs=None)
     p.add_volume(
         sg.active_attributes,
         opacity='linear'
     )
     p.add_axes()
     p.add_bounding_box()
-    p.show()
+    image_2d = True
+    if image_2d is False:
+        p.show()
+    else:
+        pyvista_to_matplotlib(p)
+
+
+

--- a/tests/test_io/test_volumes/test_import_grav3d.py
+++ b/tests/test_io/test_volumes/test_import_grav3d.py
@@ -6,31 +6,44 @@ import numpy as np
 
 import subsurface
 from subsurface import StructuredGrid
-from subsurface.modules.reader.volume.read_grav3d import MeshData, read_msh_file, read_mod_file, structured_data_from
+from subsurface.modules.reader.volume.read_grav3d import (
+    GridData, read_msh_file, read_mod_file, structured_data_from
+)
 from subsurface.modules.visualization import init_plotter
 
 dotenv.load_dotenv()
 
 
 def test_import_grav3d():
+    """
+    Test importing and visualizing a Grav3D model.
+
+    This test reads a Grav3D mesh and model file, converts them to a StructuredGrid,
+    and visualizes the result using PyVista.
+    """
     import pyvista as pv
-    mesh: MeshData = read_msh_file(os.getenv("PATH_TO_GRAV3D_MSH"))
 
-    assert mesh is not None
-    assert mesh.dimensions.ne == 250
+    # Read the mesh file to get grid information
+    grid: GridData = read_msh_file(os.getenv("PATH_TO_GRAV3D_MSH"))
 
+    # Verify the grid was loaded correctly
+    assert grid is not None
+    assert grid.dimensions.nx == 250  # Using the new property name
+
+    # Read the model file to get property values
     array: np.ndarray = read_mod_file(
-        filepath=(pathlib.Path(os.getenv("PATH_TO_GRAV3D_MOD"))),
-        mesh=mesh
+        filepath=pathlib.Path(os.getenv("PATH_TO_GRAV3D_MOD")),
+        grid=grid  # Using the new parameter name
     )
-    
-    # Compute cell-center coordinates for each axis.
-    # For easting, start from origin.x0 and add cumulative cell widths.
-    struct = structured_data_from(array, mesh)
 
+    # Convert the array and grid to a structured data format
+    struct = structured_data_from(array, grid)
+
+    # Create a StructuredGrid from the structured data
     sg: subsurface.StructuredGrid = StructuredGrid(struct)
 
-    p: pv.Pll = init_plotter(image_2d=False, ve=1, plotter_kwargs=None)
+    # Visualize the grid
+    p = init_plotter(image_2d=False, ve=1, plotter_kwargs=None)
     p.add_volume(
         sg.active_attributes,
         opacity='linear'
@@ -38,5 +51,3 @@ def test_import_grav3d():
     p.add_axes()
     p.add_bounding_box()
     p.show()
-
-

--- a/tests/test_io/test_volumes/test_import_grav3d.py
+++ b/tests/test_io/test_volumes/test_import_grav3d.py
@@ -1,0 +1,72 @@
+﻿import os
+import pathlib
+
+import dotenv
+import numpy as np
+
+import subsurface
+from subsurface import StructuredGrid
+from subsurface.modules.reader.volume.read_grav3d import MeshData, read_msh_file, read_mod_file
+from subsurface.modules.visualization import to_pyvista_grid, pv_plot
+
+dotenv.load_dotenv()
+
+
+def test_import_grav3d():
+    mesh: MeshData = read_msh_file(os.getenv("PATH_TO_GRAV3D_MSH"))
+
+    assert mesh is not None
+    assert mesh.dimensions.ne == 250
+
+    array: np.ndarray = read_mod_file(
+        filepath=(pathlib.Path(os.getenv("PATH_TO_GRAV3D_MOD"))),
+        mesh=mesh
+    )
+    
+    foo = np.unique(array).min()
+    # Compute cell-center coordinates for each axis.
+    # For easting, start from origin.x0 and add cumulative cell widths.
+    easting = np.array(mesh.cell_sizes.easting)
+    x_centers = mesh.origin.x0 + np.cumsum(easting) - easting[0] / 2
+
+    # For northing, start from origin.y0
+    northing = np.array(mesh.cell_sizes.northing)
+    y_centers = mesh.origin.y0 + np.cumsum(northing) - northing[0] / 2
+
+    # For vertical, note that the top is given by origin.z0 and cells extend downward.
+    vertical = np.array(mesh.cell_sizes.vertical)
+    z_centers = mesh.origin.z0 - (np.cumsum(vertical) - vertical[0] / 2)
+
+    # Create the DataArray.
+    # The array shape is (nn, ne, nz). We use dimension names 'north', 'east' and 'vertical'
+    import xarray as xr
+    xr_data_array = xr.DataArray(
+        data=array,
+        dims=['x', 'y', 'z'],
+        coords={
+            'x': y_centers,
+            'y': x_centers,
+            'z': z_centers,
+        },
+        name='model'
+    )
+    
+    xr_data_array.plot()
+
+    # Optionally, wrap the xr.DataArray into a StructuredData instance
+    struct: subsurface.StructuredData = subsurface.StructuredData.from_data_array(
+        data_array=xr_data_array,
+        data_array_name='model'
+    )
+
+    # sg: subsurface.StructuredGrid = StructuredGrid(struct)
+    # import pyvista as pv
+    # pyvista_mesh:pv.StructuredGrid = to_pyvista_grid(sg)
+    # pyvista_mesh = pyvista_mesh.threshold(0, scalars="model")
+    # 
+    # scalars = pyvista_mesh.active_scalars
+    # foo = np.unique(scalars)
+    # # plot as points
+    # plotter = pv.Plotter()
+    # plotter.add_mesh(pyvista_mesh)
+    # plotter.show()

--- a/tests/test_io/test_volumes/test_import_grav3d.py
+++ b/tests/test_io/test_volumes/test_import_grav3d.py
@@ -3,16 +3,18 @@ import pathlib
 
 import dotenv
 import numpy as np
+from matplotlib import pyplot as plt
 
 import subsurface
 from subsurface import StructuredGrid
 from subsurface.modules.reader.volume.read_grav3d import MeshData, read_msh_file, read_mod_file
-from subsurface.modules.visualization import to_pyvista_grid, pv_plot
+from subsurface.modules.visualization import to_pyvista_grid, pv_plot, init_plotter
 
 dotenv.load_dotenv()
 
 
 def test_import_grav3d():
+    import pyvista as pv
     mesh: MeshData = read_msh_file(os.getenv("PATH_TO_GRAV3D_MSH"))
 
     assert mesh is not None
@@ -22,8 +24,35 @@ def test_import_grav3d():
         filepath=(pathlib.Path(os.getenv("PATH_TO_GRAV3D_MOD"))),
         mesh=mesh
     )
-    
-    foo = np.unique(array).min()
+    # arr = array
+    # # arr = np.random.random((100, 100, 100))
+    # arr.shape
+    # ba = np.unique(arr)
+    # vol = pv.ImageData()
+    # vol.dimensions = arr.shape
+    # vol["array"] = arr.ravel(order="F")
+    # 
+    # p: pv.Pll = init_plotter(image_2d=False, ve=1, plotter_kwargs=None)
+    # 
+    # p.add_volume(
+    #     vol,
+    #     opacity="sigmoid",
+    #     # show_axes=True,
+    #     # show_bounds=True,
+    # )
+    # p.show()
+    # plot 3d numpy array as structured grid in pyvista
+    # vol.plot(
+    #     # nan_opacity=0
+    #     opacity="sigmoid",
+    #     # style="points",
+    #     show_axes=True,
+    #     show_bounds=True,
+    #     volume=True,
+    #     # show_edges=True    
+    # )
+    # # foo
+
     # Compute cell-center coordinates for each axis.
     # For easting, start from origin.x0 and add cumulative cell widths.
     easting = np.array(mesh.cell_sizes.easting)
@@ -44,14 +73,15 @@ def test_import_grav3d():
         data=array,
         dims=['x', 'y', 'z'],
         coords={
-            'x': y_centers,
-            'y': x_centers,
-            'z': z_centers,
+                'x': y_centers,
+                'y': x_centers,
+                'z': z_centers,
         },
         name='model'
     )
-    
+
     xr_data_array.plot()
+    plt.show()
 
     # Optionally, wrap the xr.DataArray into a StructuredData instance
     struct: subsurface.StructuredData = subsurface.StructuredData.from_data_array(
@@ -59,14 +89,49 @@ def test_import_grav3d():
         data_array_name='model'
     )
 
-    # sg: subsurface.StructuredGrid = StructuredGrid(struct)
-    # import pyvista as pv
-    # pyvista_mesh:pv.StructuredGrid = to_pyvista_grid(sg)
-    # pyvista_mesh = pyvista_mesh.threshold(0, scalars="model")
-    # 
-    # scalars = pyvista_mesh.active_scalars
-    # foo = np.unique(scalars)
-    # # plot as points
-    # plotter = pv.Plotter()
-    # plotter.add_mesh(pyvista_mesh)
-    # plotter.show()
+    sg: subsurface.StructuredGrid = StructuredGrid(struct)
+
+    p: pv.Pll = init_plotter(image_2d=False, ve=1, plotter_kwargs=None)
+    p.add_volume(
+        sg.active_attributes,
+        # opacity="sigmoid",
+    )
+    p.add_axes()
+    p.add_bounding_box()
+    p.show()
+
+    # volume = to_pyvista_grid(sg)
+    # volume.plot(
+    #     volume=True,
+    #          opacity="sigmoid",
+    # )
+    # Filter nans
+
+    # p: pv.Pll = init_plotter(image_2d=False, ve=1, plotter_kwargs=None)
+    # return 
+    # p.add_volume(
+    #     volume,
+    #     opacity="sigmoid",
+    #     scalars="model"
+    #     # show_axes=True,
+    #     # show_bounds=True,
+    # )
+    # p.show()
+    # mesh.plot(
+    #     nan_opacity=0,
+    #     style="points"
+    # )
+    # pv_plot(
+    #     meshes=[mesh],
+    #     image_2d=False,
+    #     plotter_kwargs=
+    #     {
+    #             "volume": True,
+    #     },
+    #     add_mesh_kwargs=
+    #     {
+    #             "nan_color"  : "white",
+    #             "nan_opacity": 0,
+    #             "scalars"    : "model"
+    #     }
+    # )

--- a/tests/test_io/test_volumes/test_import_grav3d.py
+++ b/tests/test_io/test_volumes/test_import_grav3d.py
@@ -3,12 +3,11 @@ import pathlib
 
 import dotenv
 import numpy as np
-from matplotlib import pyplot as plt
 
 import subsurface
 from subsurface import StructuredGrid
-from subsurface.modules.reader.volume.read_grav3d import MeshData, read_msh_file, read_mod_file
-from subsurface.modules.visualization import to_pyvista_grid, pv_plot, init_plotter
+from subsurface.modules.reader.volume.read_grav3d import MeshData, read_msh_file, read_mod_file, structured_data_from
+from subsurface.modules.visualization import init_plotter
 
 dotenv.load_dotenv()
 
@@ -24,114 +23,20 @@ def test_import_grav3d():
         filepath=(pathlib.Path(os.getenv("PATH_TO_GRAV3D_MOD"))),
         mesh=mesh
     )
-    # arr = array
-    # # arr = np.random.random((100, 100, 100))
-    # arr.shape
-    # ba = np.unique(arr)
-    # vol = pv.ImageData()
-    # vol.dimensions = arr.shape
-    # vol["array"] = arr.ravel(order="F")
-    # 
-    # p: pv.Pll = init_plotter(image_2d=False, ve=1, plotter_kwargs=None)
-    # 
-    # p.add_volume(
-    #     vol,
-    #     opacity="sigmoid",
-    #     # show_axes=True,
-    #     # show_bounds=True,
-    # )
-    # p.show()
-    # plot 3d numpy array as structured grid in pyvista
-    # vol.plot(
-    #     # nan_opacity=0
-    #     opacity="sigmoid",
-    #     # style="points",
-    #     show_axes=True,
-    #     show_bounds=True,
-    #     volume=True,
-    #     # show_edges=True    
-    # )
-    # # foo
-
+    
     # Compute cell-center coordinates for each axis.
     # For easting, start from origin.x0 and add cumulative cell widths.
-    easting = np.array(mesh.cell_sizes.easting)
-    x_centers = mesh.origin.x0 + np.cumsum(easting) - easting[0] / 2
-
-    # For northing, start from origin.y0
-    northing = np.array(mesh.cell_sizes.northing)
-    y_centers = mesh.origin.y0 + np.cumsum(northing) - northing[0] / 2
-
-    # For vertical, note that the top is given by origin.z0 and cells extend downward.
-    vertical = np.array(mesh.cell_sizes.vertical)
-    z_centers = mesh.origin.z0 - (np.cumsum(vertical) - vertical[0] / 2)
-
-    # Create the DataArray.
-    # The array shape is (nn, ne, nz). We use dimension names 'north', 'east' and 'vertical'
-    import xarray as xr
-    xr_data_array = xr.DataArray(
-        data=array,
-        dims=['x', 'y', 'z'],
-        coords={
-                'x': y_centers,
-                'y': x_centers,
-                'z': z_centers,
-        },
-        name='model'
-    )
-
-    xr_data_array.plot()
-    plt.show()
-
-    # Optionally, wrap the xr.DataArray into a StructuredData instance
-    struct: subsurface.StructuredData = subsurface.StructuredData.from_data_array(
-        data_array=xr_data_array,
-        data_array_name='model'
-    )
+    struct = structured_data_from(array, mesh)
 
     sg: subsurface.StructuredGrid = StructuredGrid(struct)
 
     p: pv.Pll = init_plotter(image_2d=False, ve=1, plotter_kwargs=None)
     p.add_volume(
         sg.active_attributes,
-        # opacity="sigmoid",
+        opacity='linear'
     )
     p.add_axes()
     p.add_bounding_box()
     p.show()
 
-    # volume = to_pyvista_grid(sg)
-    # volume.plot(
-    #     volume=True,
-    #          opacity="sigmoid",
-    # )
-    # Filter nans
 
-    # p: pv.Pll = init_plotter(image_2d=False, ve=1, plotter_kwargs=None)
-    # return 
-    # p.add_volume(
-    #     volume,
-    #     opacity="sigmoid",
-    #     scalars="model"
-    #     # show_axes=True,
-    #     # show_bounds=True,
-    # )
-    # p.show()
-    # mesh.plot(
-    #     nan_opacity=0,
-    #     style="points"
-    # )
-    # pv_plot(
-    #     meshes=[mesh],
-    #     image_2d=False,
-    #     plotter_kwargs=
-    #     {
-    #             "volume": True,
-    #     },
-    #     add_mesh_kwargs=
-    #     {
-    #             "nan_color"  : "white",
-    #             "nan_opacity": 0,
-    #             "scalars"    : "model"
-    #     }
-    # )

--- a/tests/test_io/test_volumes/test_import_grav3d.py
+++ b/tests/test_io/test_volumes/test_import_grav3d.py
@@ -3,6 +3,7 @@ import pathlib
 
 import dotenv
 import numpy as np
+from matplotlib import pyplot as plt
 
 import subsurface
 from subsurface import StructuredGrid
@@ -21,8 +22,6 @@ def test_import_grav3d():
     This test reads a Grav3D mesh and model file, converts them to a StructuredGrid,
     and visualizes the result using PyVista.
     """
-    import pyvista as pv
-
     # Read the mesh file to get grid information
     grid: GridData = read_msh_file(os.getenv("PATH_TO_GRAV3D_MSH"))
 
@@ -36,6 +35,89 @@ def test_import_grav3d():
         grid=grid  # Using the new parameter name
     )
 
+    # Convert the array and grid to a structured data format
+    struct = structured_data_from(array, grid)
+
+    # Create a StructuredGrid from the structured data
+    sg: subsurface.StructuredGrid = StructuredGrid(struct)
+
+    # Visualize the grid
+    p = init_plotter(image_2d=False, ve=1, plotter_kwargs=None)
+    p.add_volume(
+        sg.active_attributes,
+        opacity='linear'
+    )
+    p.add_axes()
+    p.add_bounding_box()
+    p.show()
+
+
+def test_import_grav3d_II():
+    """
+    Test importing and visualizing a Grav3D model.
+
+    This test reads a Grav3D mesh and model file, converts them to a StructuredGrid,
+    and visualizes the result using PyVista.
+    """
+    # Read the mesh file to get grid information
+    path_to_folder = os.getenv("PATH_TO_GRAV3D_MSH_II")
+    grid: GridData = read_msh_file(path_to_folder + "/mesh.msh")
+
+    # Verify the grid was loaded correctly
+    assert grid is not None
+    assert grid.dimensions.nx == 100  # Using the new property name
+
+    # Read the model file to get property values
+    array: np.ndarray = read_mod_file(
+        filepath=pathlib.Path(path_to_folder + "/grav.den"),
+        grid=grid,  # Using the new parameter name
+        missing_value= -1e+08
+    )
+
+    # Convert the array and grid to a structured data format
+    struct = structured_data_from(array, grid)
+    struct.active_data_array.plot()
+    plt.show()
+
+    assert array is not None
+    assert array.shape == (139, 100, 46)  # Check the shape of the array
+
+    # Create a StructuredGrid from the structured data
+    sg: subsurface.StructuredGrid = StructuredGrid(struct)
+
+    # Visualize the grid
+    p = init_plotter(image_2d=False, ve=1, plotter_kwargs=None)
+    p.add_volume(
+        sg.active_attributes,
+        opacity='linear'
+    )
+    p.add_axes()
+    p.add_bounding_box()
+    p.show()
+
+
+def test_import_grav3d_III():
+    """
+    Test importing and visualizing a Grav3D model.
+
+    This test reads a Grav3D mesh and model file, converts them to a StructuredGrid,
+    and visualizes the result using PyVista.
+    """
+    # Read the mesh file to get grid information
+    path_to_folder = os.getenv("PATH_TO_GRAV3D_MSH_II")
+    grid: GridData = read_msh_file(path_to_folder + "/mesh.msh")
+
+    # Verify the grid was loaded correctly
+    assert grid is not None
+    assert grid.dimensions.nx == 100  # Using the new property name
+
+    # Read the model file to get property values
+    array: np.ndarray = read_mod_file(
+        filepath=pathlib.Path(path_to_folder + "/muon.den"),
+        grid=grid  # Using the new parameter name
+    )
+    assert array is not None
+    assert array.shape == (139, 100, 46)  # Check the shape of the array
     # Convert the array and grid to a structured data format
     struct = structured_data_from(array, grid)
 

--- a/tests/test_io/test_volumes/test_import_volume_vtk.py
+++ b/tests/test_io/test_volumes/test_import_volume_vtk.py
@@ -137,7 +137,7 @@ def test_vtk_file_to_structured_data__gen11818__idn63() -> subsurface.Structured
     pv = optional_requirements.require_pyvista()
 
     devops_path = pathlib.Path(os.getenv('TERRA_PATH_DEVOPS'))
-    filepath = devops_path.joinpath(r"volume\VTK\IDN-63\muon.vtk")
+    filepath = devops_path.joinpath(r"volume/VTK/IDN-63/muon.vtk")
 
     pyvista_obj: pv.DataSet = pv.read(filepath)
     pv.examples.download_angular_sector()


### PR DESCRIPTION
### TL;DR

Added support for reading Grav3D mesh and model files.

### What changed?

- Created a new module `read_grav3d.py` with functions to parse Grav3D mesh (.msh) and model (.mod) files
- Implemented data classes for structured representation of mesh data (GridDimensions, GridOrigin, GridCellSizes, GridData)
- Added functionality to handle different notation formats in mesh files (expanded or N*value notation)
- Implemented conversion of model data to numpy arrays with proper reshaping
- Added automatic conversion of missing values to NaN in model data
- Added `active_attributes` property to StructuredGrid class for easier access to active data array values

### How to test?

A test file `test_import_grav3d.py` has been added that:
- Reads a Grav3D mesh file using environment variables for file paths
- Loads the corresponding model file
- Converts the data to xarray format with proper coordinates
- Creates a StructuredGrid instance from the structured data
- Visualizes the model using PyVista and matplotlib

### Why make this change?

This addition enables subsurface to work with Grav3D gravity inversion data, expanding the library's capabilities to handle geophysical models. The implementation provides a clean, structured way to load these specialized files and convert them to standard subsurface data structures for further analysis and visualization.