### PR TITLE
[ENH] Add MSH stream to structured data conversion | GEN-11953

### DIFF
--- a/subsurface/api/__init__.py
+++ b/subsurface/api/__init__.py
@@ -8,5 +8,6 @@ from .interfaces.stream import (
     VTK_stream_to_struct,  
     MX_stream_to_unstruc,
     OBJ_stream_to_trisurf,
-    GLTF_stream_to_trisurf
+    GLTF_stream_to_trisurf,
+    MSH_stream_to_struct,
 )

--- a/subsurface/api/interfaces/stream.py
+++ b/subsurface/api/interfaces/stream.py
@@ -57,8 +57,14 @@ def GLTF_stream_to_trisurf(gltf_stream: io.BytesIO, coordinate_system: TriMeshTr
     tri_mesh: TriSurf = reader.load_gltf_with_trimesh(gltf_stream, coordinate_system)
     return tri_mesh
 
+
 def VTK_stream_to_struct(stream: BytesIO, attribute_name: str) -> list[StructuredData]:
     struct = read_VTK_structured_grid(stream, attribute_name)
+    return [struct]
+
+
+def MSH_stream_to_struct(grid_stream: TextIO, values_stream: TextIO) -> list[StructuredData]:
+    struct = reader.read_msh_structured_grid(grid_stream, values_stream)
     return [struct]
 
 

--- a/subsurface/api/interfaces/stream.py
+++ b/subsurface/api/interfaces/stream.py
@@ -1,6 +1,6 @@
 import io
 from io import BytesIO
-from typing import TextIO
+from typing import TextIO, Optional
 
 import pandas
 
@@ -63,8 +63,8 @@ def VTK_stream_to_struct(stream: BytesIO, attribute_name: str) -> list[Structure
     return [struct]
 
 
-def MSH_stream_to_struct(grid_stream: TextIO, values_stream: TextIO) -> list[StructuredData]:
-    struct = reader.read_msh_structured_grid(grid_stream, values_stream)
+def MSH_stream_to_struct(grid_stream: TextIO, values_stream: TextIO, missing_value: Optional[float], attr_name: Optional[str]) -> list[StructuredData]:
+    struct = reader.read_msh_structured_grid(grid_stream, values_stream, missing_value, attr_name)
     return [struct]
 
 

--- a/subsurface/modules/reader/__init__.py
+++ b/subsurface/modules/reader/__init__.py
@@ -9,3 +9,5 @@ from .mesh.dxf_reader import dxf_stream_to_unstruct_input, dxf_file_to_unstruct_
 from .mesh.mx_reader import mx_to_unstruc_from_binary
 from .mesh.obj_reader import load_obj_with_trimesh, load_obj_with_trimesh_from_binary
 from .mesh.glb_reader import load_gltf_with_trimesh
+
+from .volume.read_grav3d import read_msh_structured_grid


### PR DESCRIPTION
# [ENH] Adding MSH stream support for structured grids

Added `MSH_stream_to_struct` function to enable reading structured grid data from streams rather than file paths. This allows loading data directly from memory or remote sources like Azure blob storage.

Refactored the grid parsing logic to improve code organization by:
- Extracting common parsing functionality into private helper methods
- Adding support for optional `missing_value` and `attr_name` parameters
- Improving error handling with more context-specific messages

The implementation maintains compatibility with existing file-based methods while adding stream-based alternatives.