### PR TITLE
[BUG] Converting boreholes with lithologies to binary was raising an issue because one of the attr dtype was string

### DIFF
--- a/subsurface/core/structs/base_structures/_aux.py
+++ b/subsurface/core/structs/base_structures/_aux.py
@@ -1,0 +1,69 @@
+import pandas as pd
+
+
+def safe_convert_to_float32(df: pd.DataFrame, error_handling: str = 'raise') -> pd.DataFrame:
+    """
+    Convert DataFrame columns to float32, handling non-convertible columns.
+
+    Args:
+        df: DataFrame to convert
+        error_handling: How to handle non-convertible columns:
+            - 'raise': Raise an error
+            - 'skip': Skip non-convertible columns
+            - 'drop': Drop non-convertible columns
+
+    Returns:
+        DataFrame with converted columns
+    """
+    convertible, non_convertible = _check_convertible_to_float32(df)
+
+    if non_convertible:
+        if error_handling == 'raise':
+            raise ValueError(
+                f"Cannot convert columns to float32: {non_convertible}. "
+                f"These columns contain non-numeric data."
+            )
+        elif error_handling == 'skip':
+            # Only convert the convertible columns
+            result = df.copy()
+            for col in convertible:
+                result[col] = df[col].astype('float32')
+            return result
+        elif error_handling == 'drop':
+            # Drop non-convertible columns
+            return df[convertible].astype('float32')
+        else:
+            raise ValueError(f"Invalid error_handling: {error_handling}")
+
+    return df.astype('float32')
+
+
+def _check_convertible_to_float32(df: pd.DataFrame) -> tuple[list[str], list[str]]:
+    """
+    Check which columns in a DataFrame can be safely converted to float32.
+
+    Returns:
+        tuple: (convertible_columns, non_convertible_columns)
+    """
+    convertible = []
+    non_convertible = []
+
+    for col in df.columns:
+        if pd.api.types.is_numeric_dtype(df[col]):
+            # Already numeric, can convert
+            convertible.append(col)
+        elif pd.api.types.is_bool_dtype(df[col]):
+            # Boolean can be converted (True->1.0, False->0.0)
+            convertible.append(col)
+        elif pd.api.types.is_string_dtype(df[col]) or pd.api.types.is_object_dtype(df[col]):
+            # Try to convert to numeric
+            try:
+                pd.to_numeric(df[col], errors='raise')
+                convertible.append(col)
+            except (ValueError, TypeError):
+                non_convertible.append(col)
+        else:
+            # Other types (datetime, timedelta, categorical, etc.)
+            non_convertible.append(col)
+
+    return convertible, non_convertible

--- a/subsurface/core/structs/base_structures/unstructured_data.py
+++ b/subsurface/core/structs/base_structures/unstructured_data.py
@@ -299,6 +299,25 @@ class UnstructuredData:
         bytearray_le = vertex + cells + cell_attribute + vertex_attribute
         return bytearray_le
 
+    def _to_bytearray(self, order):
+        from subsurface.core.structs.base_structures._aux import safe_convert_to_float32
+        vertex = self.vertex.astype('float32').tobytes(order)
+        cells = self.cells.astype('int32').tobytes(order)
+
+        # Only include numeric columns
+        cell_attribute = safe_convert_to_float32(
+            self.attributes,
+            error_handling='drop'
+        ).values.tobytes(order)
+
+        vertex_attribute = safe_convert_to_float32(
+            self.points_attributes,
+            error_handling='drop'
+        ).values.tobytes(order)
+
+        bytearray_le = vertex + cells + cell_attribute + vertex_attribute
+        return bytearray_le
+
     def _validate(self):
         try:
             _ = self.data[self.cells_attr_name]['cell']

--- a/tests/test_io/test_lines/test_lines_III.py
+++ b/tests/test_io/test_lines/test_lines_III.py
@@ -27,6 +27,7 @@ pytestmark = pytest.mark.skipif(
     reason="Need to set the READ_MESH"
 )
 
+
 @pytest.mark.liquid_earth
 def test_read_kim():
     collar_df: pd.DataFrame = read_collar(
@@ -73,6 +74,9 @@ def test_read_kim():
         survey=survey,
         merge_option=MergeOptions.INTERSECT
     )
+    
+    borehole_set.collars.data.to_binary()
+    borehole_set.combined_trajectory.data.to_binary()
 
     _plot(
         scalar="lith_ids",


### PR DESCRIPTION
# Add safe float32 conversion for binary serialization

- Added `safe_convert_to_float32` utility function to handle DataFrame column conversions to float32 with different error handling strategies
- Implemented `_check_convertible_to_float32` helper to identify which columns can be safely converted
- Updated `_to_bytearray` method to use the new safe conversion utilities when serializing vertex and cell data
- Extended tests to validate binary data conversion functionality with non-numeric attributes