### PR TITLE
[PACKAGE] Update code to make it compatible with pandas 3.0

### DIFF
--- a/subsurface/core/geological_formats/boreholes/_map_attrs_to_survey.py
+++ b/subsurface/core/geological_formats/boreholes/_map_attrs_to_survey.py
@@ -231,6 +231,11 @@ def _map_attrs_to_measured_depths(attrs: pd.DataFrame, survey_trajectory: LineSe
                 is_categorical
             )
 
+            # Convert to appropriate dtype to avoid pandas 3.0 dtype coercion errors
+            target_dtype = new_attrs[col].dtype
+            if pd.api.types.is_numeric_dtype(target_dtype) and not is_categorical:
+                interpolated_values = np.asarray(interpolated_values, dtype=target_dtype)
+                
             new_attrs.loc[well_mask, col] = interpolated_values
 
     return new_attrs

--- a/subsurface/core/geological_formats/boreholes/_map_attrs_to_survey.py
+++ b/subsurface/core/geological_formats/boreholes/_map_attrs_to_survey.py
@@ -216,7 +216,7 @@ def _map_attrs_to_measured_depths(attrs: pd.DataFrame, survey_trajectory: LineSe
                 continue
 
             attr_values = attrs_well[col]
-            is_categorical = attr_values.dtype == 'O' or isinstance(attr_values.dtype, pd.CategoricalDtype)
+            is_categorical = attr_values.dtype == 'O' or isinstance(attr_values.dtype, pd.CategoricalDtype) or isinstance(attr_values.dtype, pd.StringDtype)
 
             # Skip columns that can't be interpolated and aren't categorical
             if is_categorical and col not in ['lith_ids', 'component lith']:

--- a/subsurface/core/reader_helpers/readers_data.py
+++ b/subsurface/core/reader_helpers/readers_data.py
@@ -28,7 +28,7 @@ class GenericReaderFilesHelper(BaseModel):
     col_names: Optional[List[Union[str, int]]] = None
     drop_cols: Optional[List[str]] = None
     format: Optional[SupportedFormats] = None
-    separator: Optional[str] = ","
+    separator: Optional[str] = None
     index_map: Optional[dict] = None  # Adjusted for serialization
     columns_map: Optional[dict] = None  # Adjusted for serialization
     additional_reader_kwargs: dict = Field(default_factory=dict)

--- a/subsurface/core/reader_helpers/readers_data.py
+++ b/subsurface/core/reader_helpers/readers_data.py
@@ -28,7 +28,7 @@ class GenericReaderFilesHelper(BaseModel):
     col_names: Optional[List[Union[str, int]]] = None
     drop_cols: Optional[List[str]] = None
     format: Optional[SupportedFormats] = None
-    separator: Optional[str] = None
+    separator: Optional[str] = ","
     index_map: Optional[dict] = None  # Adjusted for serialization
     columns_map: Optional[dict] = None  # Adjusted for serialization
     additional_reader_kwargs: dict = Field(default_factory=dict)

--- a/subsurface/modules/reader/wells/_read_to_df.py
+++ b/subsurface/modules/reader/wells/_read_to_df.py
@@ -15,6 +15,7 @@ def check_format_and_read_to_df(reader_helper: GenericReaderFilesHelper) -> pd.D
             reader: Callable = _get_reader(reader_helper.format)
             d = reader(
                 filepath_or_buffer=reader_helper.file_or_buffer,
+                engine='python',
                 **reader_helper.pandas_reader_kwargs
             )
         case (bytes() | io.BytesIO() | io.StringIO() | io.TextIOWrapper()), _:

--- a/subsurface/modules/reader/wells/_read_to_df.py
+++ b/subsurface/modules/reader/wells/_read_to_df.py
@@ -15,7 +15,6 @@ def check_format_and_read_to_df(reader_helper: GenericReaderFilesHelper) -> pd.D
             reader: Callable = _get_reader(reader_helper.format)
             d = reader(
                 filepath_or_buffer=reader_helper.file_or_buffer,
-                sep=reader_helper.separator,
                 **reader_helper.pandas_reader_kwargs
             )
         case (bytes() | io.BytesIO() | io.StringIO() | io.TextIOWrapper()), _:

--- a/subsurface/modules/reader/wells/_read_to_df.py
+++ b/subsurface/modules/reader/wells/_read_to_df.py
@@ -15,6 +15,7 @@ def check_format_and_read_to_df(reader_helper: GenericReaderFilesHelper) -> pd.D
             reader: Callable = _get_reader(reader_helper.format)
             d = reader(
                 filepath_or_buffer=reader_helper.file_or_buffer,
+                sep=reader_helper.separator,
                 engine='python',
                 **reader_helper.pandas_reader_kwargs
             )


### PR DESCRIPTION
### TL;DR

Set default separator to comma in `GenericReaderFilesHelper` and remove explicit separator parameter in file reading.

### What changed?

- Changed the default value for `separator` from `None` to `","` in the `GenericReaderFilesHelper` class
- Removed the explicit `sep` parameter from the reader function call in `check_format_and_read_to_df`, allowing it to use the default separator or one specified in `pandas_reader_kwargs`

### How to test?

1. Test reading files with comma separators without explicitly specifying a separator
2. Test reading files with non-comma separators by specifying the separator in `pandas_reader_kwargs`
3. Verify that existing code using `GenericReaderFilesHelper` still works correctly with the new default

### Why make this change?

This change simplifies the file reading process by setting a sensible default separator (comma) and removing redundant parameter passing. It allows the pandas reader to use either the default comma separator or a custom one specified in the additional kwargs, making the code more maintainable and reducing parameter duplication.