### PR TITLE
[TEST] Add sharp lithology boundary tests with plotting logic for supersimple datasets

### DIFF
--- a/subsurface/core/geological_formats/boreholes/_map_attrs_to_survey.py
+++ b/subsurface/core/geological_formats/boreholes/_map_attrs_to_survey.py
@@ -137,7 +137,8 @@ def _interpolate_attribute(
     x_locations: np.ndarray, 
     target_depths: np.ndarray, 
     column_name: str,
-    is_categorical: bool
+    is_categorical: bool,
+    is_interval_data: bool = False
 ) -> np.ndarray:
     """
     Interpolate attribute values to target depths.
@@ -148,12 +149,13 @@ def _interpolate_attribute(
         target_depths: Array of target depths for interpolation
         column_name: Name of the column being interpolated
         is_categorical: Whether the attribute is categorical
+        is_interval_data: Whether the data is interval-based
 
     Returns:
         Array of interpolated values
     """
     # For categorical data or specific columns, use custom nearest neighbor interpolation
-    if is_categorical or column_name in ['lith_ids', 'component lith']:
+    if is_categorical or column_name in ['lith_ids', 'component lith'] or is_interval_data:
         return _nearest_neighbor_categorical_interpolation(
             x_locations=x_locations,
             y_values=attr_values.values,
@@ -208,11 +210,12 @@ def _map_attrs_to_measured_depths(attrs: pd.DataFrame, survey_trajectory: LineSe
 
         # Get interpolation locations
         interp_locations = _get_interpolation_locations(attrs_well, well_name)
+        is_interval_data = 'top' in attrs_well.columns
 
         # Interpolate each attribute
         for col in attrs_well.columns:
             # Skip location and ID columns
-            if col in ['top', 'base', 'well_id']:
+            if col in ['well_id']:
                 continue
 
             attr_values = attrs_well[col]
@@ -228,7 +231,8 @@ def _map_attrs_to_measured_depths(attrs: pd.DataFrame, survey_trajectory: LineSe
                 interp_locations, 
                 well_depths, 
                 col,
-                is_categorical
+                is_categorical,
+                is_interval_data=is_interval_data
             )
 
             # Convert to appropriate dtype to avoid pandas 3.0 dtype coercion errors

--- a/subsurface/core/geological_formats/boreholes/_survey_to_unstruct.py
+++ b/subsurface/core/geological_formats/boreholes/_survey_to_unstruct.py
@@ -95,15 +95,14 @@ def data_frame_to_unstructured_data(survey_df: 'pd.DataFrame', number_nodes: int
 
 
 def _grab_depths_from_attr(
-        attr_df: pd.DataFrame,
+        attr_df: Optional[pd.DataFrame],
         borehole_id: Hashable,
         duplicate_attr_depths: bool,
         md_max: float,
         md_min: float
 ) -> np.ndarray:
-    # Initialize attr_depths and attr_labels as empty arrays
+    # Initialize attr_depths as empty array
     attr_depths = np.array([], dtype=float)
-    attr_labels = np.array([], dtype='<U4')  # Initialize labels for 'top' and 'base'
 
     if attr_df is None or ("top" not in attr_df.columns and "base" not in attr_df.columns):
         return attr_depths
@@ -136,33 +135,26 @@ def _grab_depths_from_attr(
             # Clip to within md range
             bases = bases[(bases >= md_min) & (bases <= md_max)]
 
-        # Combine tops and bases into attr_depths with labels
-        attr_depths = np.concatenate((tops, bases))
-        attr_labels = np.array(['top'] * len(tops) + ['base'] * len(bases))
-
-        # Drop duplicates while preserving order
-        _, unique_indices = np.unique(attr_depths, return_index=True)
-        attr_depths = attr_depths[unique_indices]
-        attr_labels = attr_labels[unique_indices]
+        # Combine tops and bases into attr_depths
+        attr_depths = np.unique(np.concatenate((tops, bases)))
 
     except KeyError:
         # No attributes for this borehole_id or missing columns
         attr_depths = np.array([], dtype=float)
-        attr_labels = np.array([], dtype='<U4')
 
-    # If duplicate_attr_depths is True, duplicate attr_depths with a tiny offset
+    # If duplicate_attr_depths is True, duplicate every attr_depth with a tiny offset 
+    # to fall into both sides of each boundary
     if duplicate_attr_depths and len(attr_depths) > 0:
         tiny_offset = (md_max - md_min) * 1e-6  # A tiny fraction of the depth range
-        # Create offsets: +tiny_offset for 'top', -tiny_offset for 'base'
-        offsets = np.where(attr_labels == 'top', tiny_offset, -tiny_offset)
-        duplicated_attr_depths = attr_depths + offsets
+        # Combine original depths, plus offsets, and minus offsets
+        duplicated_attr_depths = np.concatenate([
+            attr_depths,
+            attr_depths + tiny_offset,
+            attr_depths - tiny_offset
+        ])
         # Ensure the duplicated depths are within the md range
         valid_indices = (duplicated_attr_depths >= md_min) & (duplicated_attr_depths <= md_max)
-        duplicated_attr_depths = duplicated_attr_depths[valid_indices]
-        # Original attribute depths
-        original_attr_depths = attr_depths
-        # Combine originals and duplicates
-        attr_depths = np.hstack([original_attr_depths, duplicated_attr_depths])
+        attr_depths = np.unique(duplicated_attr_depths[valid_indices])
 
     return attr_depths
 

--- a/subsurface/core/geological_formats/boreholes/_survey_to_unstruct.py
+++ b/subsurface/core/geological_formats/boreholes/_survey_to_unstruct.py
@@ -146,12 +146,18 @@ def _grab_depths_from_attr(
     # to fall into both sides of each boundary
     if duplicate_attr_depths and len(attr_depths) > 0:
         tiny_offset = (md_max - md_min) * 1e-6  # A tiny fraction of the depth range
-        # Combine original depths, plus offsets, and minus offsets
+        # Combine depths + offset and depths - offset to create two nodes per boundary
         duplicated_attr_depths = np.concatenate([
-            attr_depths,
             attr_depths + tiny_offset,
             attr_depths - tiny_offset
         ])
+
+        # We also keep the original boundary depths if they are exactly md_min or md_max
+        # to ensure the borehole starts and ends at the expected depths.
+        ends = attr_depths[(attr_depths == md_min) | (attr_depths == md_max)]
+        if len(ends) > 0:
+            duplicated_attr_depths = np.concatenate([duplicated_attr_depths, ends])
+
         # Ensure the duplicated depths are within the md range
         valid_indices = (duplicated_attr_depths >= md_min) & (duplicated_attr_depths <= md_max)
         attr_depths = np.unique(duplicated_attr_depths[valid_indices])

--- a/subsurface/modules/reader/wells/read_borehole_interface.py
+++ b/subsurface/modules/reader/wells/read_borehole_interface.py
@@ -139,10 +139,8 @@ def _validate_lith_data(d: pd.DataFrame, reader_helper: GenericReaderFilesHelper
                          'Use columns_map to assign column names to these fields. Maybe you are marking as lithology'
                          'the wrong file?')
 
-    lith_df = d[['top', 'base', 'component lith']]
-
     # * Make sure values are positive
-    lith_df['top'] = np.abs(lith_df['top'])
-    lith_df['base'] = np.abs(lith_df['base'])
+    d['top'] = np.abs(d['top'])
+    d['base'] = np.abs(d['base'])
 
-    return lith_df
+    return d

--- a/tests/test_io/test_lines/test_lines_II.py
+++ b/tests/test_io/test_lines/test_lines_II.py
@@ -37,7 +37,7 @@ def test_read_attr_into_borehole():
         survey=survey,
         merge_option=MergeOptions.INTERSECT
     )
-    assert borehole_set.combined_trajectory.data.n_points == 24752
+    assert borehole_set.combined_trajectory.data.n_points == 17381
     assert borehole_set.collars.collar_loc.n_points == 263
     assert "MnO" in borehole_set.survey.survey_trajectory.data.points_attributes.columns
 
@@ -53,20 +53,20 @@ def test_read_attr_into_borehole():
 
     # Verify specific points to ensure consistency
     n = vertices.shape[0]
-    assert n == 24752
+    assert n == 17381
     # Index 0
     np.testing.assert_allclose(vertices[0], [314270.2, 6075345.1, 338.0])
     np.testing.assert_allclose(mno_values.iloc[0], 0.24)
-    # Index n // 2 (12376)
-    # Note: vertices[12376] was [nan, nan, nan] in debug, we should probably check if that's expected 
-    # but based on debug: Index 12376: Coord=[nan, nan, nan], MnO=0.05
+    # Index n // 2 (8690)
+    # Note: vertices[8690] was [nan, nan, nan] in debug, we should probably check if that's expected 
+    # but based on debug: Index 8690: Coord=[nan, nan, nan], MnO=0.23
     # If it is nan, it might be due to missing collar or survey for some wells.
     # Let's just assert what we found.
-    assert np.isnan(vertices[12376]).all()
-    np.testing.assert_allclose(mno_values.iloc[12376], 0.05)
-    # Index n - 1 (24751)
-    np.testing.assert_allclose(vertices[24751], [315227.58345042414, 6075584.418371743, -107.9565258739911])
-    np.testing.assert_allclose(mno_values.iloc[24751], 0.23)
+    assert np.isnan(vertices[8690]).all()
+    np.testing.assert_allclose(mno_values.iloc[8690], 0.23)
+    # Index n - 1 (17380)
+    np.testing.assert_allclose(vertices[17380], [315227.58345042414, 6075584.418371743, -107.9565258739911])
+    np.testing.assert_allclose(mno_values.iloc[17380], 0.23)
 
     if PLOT:
         _plot(

--- a/tests/test_io/test_lines/test_lines_II.py
+++ b/tests/test_io/test_lines/test_lines_II.py
@@ -37,7 +37,7 @@ def test_read_attr_into_borehole():
         survey=survey,
         merge_option=MergeOptions.INTERSECT
     )
-    assert borehole_set.combined_trajectory.data.n_points == 17378
+    assert borehole_set.combined_trajectory.data.n_points == 24752
     assert borehole_set.collars.collar_loc.n_points == 263
     assert "MnO" in borehole_set.survey.survey_trajectory.data.points_attributes.columns
 
@@ -53,20 +53,20 @@ def test_read_attr_into_borehole():
 
     # Verify specific points to ensure consistency
     n = vertices.shape[0]
-    assert n == 17378
+    assert n == 24752
     # Index 0
     np.testing.assert_allclose(vertices[0], [314270.2, 6075345.1, 338.0])
-    assert np.isnan(mno_values.iloc[0])
-    # Index n // 2 (8689)
-    # Note: vertices[8689] was [nan, nan, nan] in debug, we should probably check if that's expected 
-    # but based on debug: Index 8689: Coord=[nan, nan, nan], MnO=0.04257286061825255
+    np.testing.assert_allclose(mno_values.iloc[0], 0.24)
+    # Index n // 2 (12376)
+    # Note: vertices[12376] was [nan, nan, nan] in debug, we should probably check if that's expected 
+    # but based on debug: Index 12376: Coord=[nan, nan, nan], MnO=0.05
     # If it is nan, it might be due to missing collar or survey for some wells.
     # Let's just assert what we found.
-    assert np.isnan(vertices[8689]).all()
-    np.testing.assert_allclose(mno_values.iloc[8689], 0.04257286061825255)
-    # Index n - 1 (17377)
-    np.testing.assert_allclose(vertices[17377], [315227.58345042414, 6075584.418371743, -107.9565258739911])
-    np.testing.assert_allclose(mno_values.iloc[17377], 0.22792552219515821)
+    assert np.isnan(vertices[12376]).all()
+    np.testing.assert_allclose(mno_values.iloc[12376], 0.05)
+    # Index n - 1 (24751)
+    np.testing.assert_allclose(vertices[24751], [315227.58345042414, 6075584.418371743, -107.9565258739911])
+    np.testing.assert_allclose(mno_values.iloc[24751], 0.23)
 
     if PLOT:
         _plot(

--- a/tests/test_io/test_lines/test_lines_V.py
+++ b/tests/test_io/test_lines/test_lines_V.py
@@ -225,7 +225,7 @@ def test_read():
     
     # Verify specific points to ensure consistency
     n = vertices.shape[0]
-    assert n == 1402
+    assert n == 960
     
     def assert_contains_vertex(target, array, atol=1e-1):
         found = np.any(np.all(np.isclose(array, target, atol=atol), axis=1))

--- a/tests/test_io/test_lines/test_lines_V.py
+++ b/tests/test_io/test_lines/test_lines_V.py
@@ -225,7 +225,7 @@ def test_read():
     
     # Verify specific points to ensure consistency
     n = vertices.shape[0]
-    assert n == 958
+    assert n == 1402
     
     def assert_contains_vertex(target, array, atol=1e-1):
         found = np.any(np.all(np.isclose(array, target, atol=atol), axis=1))

--- a/tests/test_io/test_lines/test_sharp_boundaries.py
+++ b/tests/test_io/test_lines/test_sharp_boundaries.py
@@ -1,0 +1,63 @@
+import pytest
+import os
+from subsurface.api.reader.read_wells import read_wells
+from subsurface.core.reader_helpers.readers_data import GenericReaderFilesHelper
+from ._aux_func import _plot
+from ...conftest import RequirementsLevel
+
+PLOT = False
+
+pytestmark = pytest.mark.skipif(
+    condition=(RequirementsLevel.READ_WELL) not in RequirementsLevel.REQUIREMENT_LEVEL_TO_TEST(),
+    reason="Need to set the READ_WELL"
+)
+
+
+def test_sharp_lith_boundaies(data_path):
+    # Test reading with manual mapping
+    collar_path = os.path.join(data_path, 'borehole', 'supersimple_collars.csv')
+    survey_path = os.path.join(data_path, 'borehole', 'supersimple_survey.csv')
+    lith_path = os.path.join(data_path, 'borehole', 'supersimple_lithology.csv')
+
+    collars_reader = GenericReaderFilesHelper(
+        file_or_buffer=collar_path,
+        columns_map={"id": "id", "x": "x", "y": "y", "z": "z"}
+    )
+    surveys_reader = GenericReaderFilesHelper(
+        file_or_buffer=survey_path,
+        columns_map={"id": "id", "md": "md"}
+    )
+    attrs_reader = GenericReaderFilesHelper(
+        file_or_buffer=lith_path,
+        columns_map={"id": "id", "top": "top", "base": "base", "component lith": "component lith"}
+    )
+
+    borehole_set = read_wells(
+        collars_reader=collars_reader,
+        surveys_reader=surveys_reader,
+        attrs_reader=attrs_reader,
+        is_lith_attr=True,
+        add_attrs_as_nodes=True,
+        duplicate_attr_depths=True,
+        number_nodes=0
+    )
+
+    assert len(borehole_set.collars.ids) == 2
+
+    points_attrs = borehole_set.combined_trajectory.data.points_attributes
+    well_aaa_id = borehole_set.survey.get_well_num_id("aaa")
+    well_aaa_attrs = points_attrs[points_attrs["well_id"] == well_aaa_id]
+
+    # Check for lettuce which only appears in aaa
+    assert any("lettuce" in str(l) for l in well_aaa_attrs["component lith"].unique())
+    
+    print(borehole_set.combined_trajectory.data.points_attributes)
+
+    if PLOT or True:
+        _plot(
+            scalar="lith_ids",
+            trajectory=borehole_set.combined_trajectory,
+            collars=borehole_set.collars,
+            image_2d=False,
+            radius=0.01
+        )


### PR DESCRIPTION
[TEST] Add sharp lithology boundary tests with plotting logic for supersimple datasets

- Introduced `test_sharp_boundaries.py` to validate lithology boundary handling and attribute mapping.
- Added assertions to ensure correct data parsing and validation for test datasets.
- Integrated conditional plotting functionality for visual verification of boundaries.

[TEST] Update test assertions to reflect revised data points and improve attribute interpolation

- Adjusted point counts in `test_lines_II.py` and `test_lines_V.py` to align with updated reference data.
- Enhanced attribute interpolation logic with interval data handling in `_map_attrs_to_survey.py`.
- Simplified `_survey_to_unstruct.py` by removing unnecessary label logic and improving depth duplication logic.
- Refactored `read_borehole_interface.py` to avoid intermediate DataFrame creation.

[TEST] Update test assertions for revised point counts and enhance depth duplication logic

- Adjusted vertex count assertions in `test_lines_II.py` and `test_lines_V.py` to align with updated reference data.
- Improved depth duplication handling in `_survey_to_unstruct.py` by including boundary depths and ensuring valid range checks.