### PR TITLE
Geotiff files

### DIFF
--- a/subsurface/modules/reader/topography/topo_core.py
+++ b/subsurface/modules/reader/topography/topo_core.py
@@ -1,4 +1,4 @@
-from typing import Sequence, Optional
+from typing import Sequence, Optional, Tuple
 
 import numpy as np
 
@@ -39,22 +39,58 @@ def rasterio_dataset_to_structured_data(dataset, crop_to_extent: Optional[Sequen
     else:
         window = None
 
-    data = dataset.read(1, window=window)
+    data = dataset.read(1, window=window, masked=True).filled(np.nan)
     data = np.fliplr(data.T)
     shape = data.shape
 
-    # Use window bounds if cropping, otherwise use full dataset bounds
-    if window is not None:
-        left, bottom, right, top = rasterio.windows.bounds(window, dataset.transform)
-    else:
-        left, bottom, right, top = dataset.bounds.left, dataset.bounds.bottom, dataset.bounds.right, dataset.bounds.top
+    x, y = _get_raster_center_coords(dataset, shape, window)
+    if dataset.crs is not None and dataset.crs.is_geographic:
+        x, y = _geographic_coords_to_metric_coords(x, y, dataset.crs)
 
     coords = {
-            'x': np.linspace(left, right, shape[0]),
-            'y': np.linspace(bottom, top, shape[1])
+            'x': x,
+            'y': y
     }
     structured_data = StructuredData.from_numpy(data, data_array_name='topography', coords=coords)
     return structured_data
+
+
+def _get_raster_center_coords(dataset, shape: Tuple[int, int], window=None):
+    rasterio = require_rasterio()
+
+    if window is not None:
+        transform = rasterio.windows.transform(window, dataset.transform)
+    else:
+        transform = dataset.transform
+
+    x = rasterio.transform.xy(transform, 0, np.arange(shape[0]), offset='center')[0]
+    y = rasterio.transform.xy(transform, np.arange(shape[1] - 1, -1, -1), 0, offset='center')[1]
+    return np.asarray(x), np.asarray(y)
+
+
+def _geographic_coords_to_metric_coords(x, y, crs):
+    rasterio = require_rasterio()
+    from rasterio import warp
+
+    longitude_center = float(np.nanmean(x))
+    latitude_center = float(np.nanmean(y))
+    zone = int((longitude_center + 180) // 6) + 1
+    epsg = 32600 + zone if latitude_center >= 0 else 32700 + zone
+    metric_crs = rasterio.crs.CRS.from_epsg(epsg)
+
+    x_metric, _ = warp.transform(
+        src_crs=crs,
+        dst_crs=metric_crs,
+        xs=x,
+        ys=np.full_like(x, latitude_center, dtype=float)
+    )
+    _, y_metric = warp.transform(
+        src_crs=crs,
+        dst_crs=metric_crs,
+        xs=np.full_like(y, longitude_center, dtype=float),
+        ys=y
+    )
+    return np.asarray(x_metric), np.asarray(y_metric)
 
 
 def rasterio_dataset_to_structured_data_(dataset, crop_to_extent: Optional[Sequence] = None):

--- a/subsurface/modules/reader/topography/topo_core.py
+++ b/subsurface/modules/reader/topography/topo_core.py
@@ -39,7 +39,7 @@ def rasterio_dataset_to_structured_data(dataset, crop_to_extent: Optional[Sequen
     else:
         window = None
 
-    data = dataset.read(1, window=window, masked=True).filled(np.nan)
+    data = _read_raster_band_as_float(dataset, window)
     data = np.fliplr(data.T)
     shape = data.shape
 
@@ -53,6 +53,17 @@ def rasterio_dataset_to_structured_data(dataset, crop_to_extent: Optional[Sequen
     }
     structured_data = StructuredData.from_numpy(data, data_array_name='topography', coords=coords)
     return structured_data
+
+
+def _read_raster_band_as_float(dataset, window=None):
+    data = dataset.read(1, window=window, masked=True)
+    data = data.astype(float).filled(np.nan)
+
+    if dataset.nodata is None and np.issubdtype(dataset.dtypes[0], np.unsignedinteger):
+        unsigned_max = np.iinfo(dataset.dtypes[0]).max
+        data[data == unsigned_max] = np.nan
+
+    return data
 
 
 def _get_raster_center_coords(dataset, shape: Tuple[int, int], window=None):

--- a/subsurface/modules/reader/topography/topo_core.py
+++ b/subsurface/modules/reader/topography/topo_core.py
@@ -189,7 +189,8 @@ def topography_to_unstructured_data(structured_data: StructuredData) -> Unstruct
 
 def _get_raster_window(crop_to_extent, dataset):
     from rasterio.windows import Window, from_bounds
-
+    # [4441850.0, 4588200.0, 4442350.0, 4588400.0]
+    # [441850.0,  4584200.0, 442350.0, 4584400.0]
     left, bottom, right, top = crop_to_extent
 
     window = from_bounds(

--- a/subsurface/modules/reader/topography/topo_core.py
+++ b/subsurface/modules/reader/topography/topo_core.py
@@ -11,14 +11,15 @@ from ....core.reader_helpers.reader_unstruct import ReaderUnstructuredHelper
 from ..mesh.surfaces_api import read_2d_mesh_to_unstruct
 
 
-def read_structured_topography(path, crop_to_extent: Optional[Sequence] = None) -> StructuredData:
+def read_structured_topography(path, crop_to_extent: Optional[Sequence] = None, band: Optional[int] = None) -> StructuredData:
     rasterio = require_rasterio()
 
     extension = get_extension(path)
     if extension == '.tif':
         structured_data = rasterio_dataset_to_structured_data(
             dataset=rasterio.open(path),
-            crop_to_extent=crop_to_extent
+            crop_to_extent=crop_to_extent,
+            band=band
         )
     else:
         raise NotImplementedError('The extension given cannot be read yet')
@@ -31,7 +32,7 @@ def read_structured_topography_to_unstructured(path) -> UnstructuredData:
     return topography_to_unstructured_data(structured_data)
 
 
-def rasterio_dataset_to_structured_data(dataset, crop_to_extent: Optional[Sequence] = None):
+def rasterio_dataset_to_structured_data(dataset, crop_to_extent: Optional[Sequence] = None, band: Optional[int] = None):
     rasterio = require_rasterio()
 
     if crop_to_extent is not None:
@@ -39,7 +40,8 @@ def rasterio_dataset_to_structured_data(dataset, crop_to_extent: Optional[Sequen
     else:
         window = None
 
-    data = _read_raster_band_as_float(dataset, window)
+    band = _select_raster_band(dataset, window, band)
+    data = _read_raster_band_as_float(dataset, window, band)
     data = np.fliplr(data.T)
     shape = data.shape
 
@@ -55,12 +57,35 @@ def rasterio_dataset_to_structured_data(dataset, crop_to_extent: Optional[Sequen
     return structured_data
 
 
-def _read_raster_band_as_float(dataset, window=None):
-    data = dataset.read(1, window=window, masked=True)
+def _select_raster_band(dataset, window=None, band: Optional[int] = None):
+    if band is not None:
+        return band
+
+    if dataset.count == 1:
+        return 1
+
+    band_scores = []
+    for band_index in dataset.indexes:
+        data = _read_raster_band_as_float(dataset, window, band_index)
+        valid_data = data[np.isfinite(data)]
+        if valid_data.size == 0:
+            band_scores.append((-1, -1, -1, band_index))
+            continue
+
+        sample = valid_data[::max(valid_data.size // 10000, 1)]
+        unique_values = np.unique(sample).size
+        value_range = float(np.nanmax(valid_data) - np.nanmin(valid_data))
+        band_scores.append((unique_values, value_range, valid_data.size, band_index))
+
+    return max(band_scores)[-1]
+
+
+def _read_raster_band_as_float(dataset, window=None, band: int = 1):
+    data = dataset.read(band, window=window, masked=True)
     data = data.astype(float).filled(np.nan)
 
-    if dataset.nodata is None and np.issubdtype(dataset.dtypes[0], np.unsignedinteger):
-        unsigned_max = np.iinfo(dataset.dtypes[0]).max
+    if dataset.nodatavals[band - 1] is None and np.issubdtype(dataset.dtypes[band - 1], np.unsignedinteger):
+        unsigned_max = np.iinfo(dataset.dtypes[band - 1]).max
         data[data == unsigned_max] = np.nan
 
     return data

--- a/subsurface/modules/reader/topography/topo_core.py
+++ b/subsurface/modules/reader/topography/topo_core.py
@@ -1,3 +1,4 @@
+from math import ceil, floor
 from typing import Sequence, Optional, Tuple
 
 import numpy as np
@@ -187,12 +188,25 @@ def topography_to_unstructured_data(structured_data: StructuredData) -> Unstruct
 
 
 def _get_raster_window(crop_to_extent, dataset):
-    from rasterio.windows import Window
-    # TODO: Add None check
-    # Get the indices of the window
+    from rasterio.windows import Window, from_bounds
+
     left, bottom, right, top = crop_to_extent
-    row_start, col_start = dataset.index(left, top)
-    row_stop, col_stop = dataset.index(right, bottom)
-    # Read the data in the window
+
+    window = from_bounds(
+        left=left,
+        bottom=bottom,
+        right=right,
+        top=top,
+        transform=dataset.transform
+    )
+
+    row_start = max(floor(window.row_off), 0)
+    col_start = max(floor(window.col_off), 0)
+    row_stop = min(ceil(window.row_off + window.height), dataset.height)
+    col_stop = min(ceil(window.col_off + window.width), dataset.width)
+
+    if row_stop <= row_start or col_stop <= col_start:
+        raise ValueError('The crop extent does not overlap the raster bounds.')
+
     window = Window.from_slices((row_start, row_stop), (col_start, col_stop))
     return window

--- a/tests/test_io/test_raster/TIF_TEST_DATA_DESCRIPTION.md
+++ b/tests/test_io/test_raster/TIF_TEST_DATA_DESCRIPTION.md
@@ -211,7 +211,7 @@ Exported from the Einstein Telescope project:
               MEMBER["European Terrestrial Reference Frame 1997"],
               MEMBER["European Terrestrial Reference Frame 2000"],
               MEMBER["European Terrestrial Reference Frame 2005"],
-              MEMBER["European Terrestrial Reference Frame 2014"],
+            ****  MEMBER["European Terrestrial Reference Frame 2014"],
               MEMBER["European Terrestrial Reference Frame 2020"],
               ELLIPSOID["GRS 1980",6378137,298.257222101,
                   LENGTHUNIT["metre",1]],

--- a/tests/test_io/test_raster/TIF_TEST_DATA_DESCRIPTION.md
+++ b/tests/test_io/test_raster/TIF_TEST_DATA_DESCRIPTION.md
@@ -1,0 +1,355 @@
+# Create GeoTIFF sample data
+
+Owner: Aaron, Miguel , Simon Virgo
+Status: Done
+Assign: Aaron
+Doing date: May 18, 2026 → May 22, 2026
+Sprints: Sprint T79, Sprint T80
+Pin: No
+ID: GEN-15151
+Parent: Import GeoTiff (1) (https://www.notion.so/Import-GeoTiff-1-32da955ff055807fa32eed1aaa7af9fa?pvs=21)
+Ideon status: Not ported
+QA Status: Info needed
+Scrum Inbox: Miguel
+Scrum Team: Tech
+
+Exported from the Einstein Telescope project:
+
+- Tiff1
+
+
+  ```
+  Driver: GTiff/GeoTIFF
+  Files: tiff1.tif
+  Size is 1408, 1405
+  Coordinate System is:
+  PROJCRS["ETRS89-extended / LCC Europe",
+      BASEGEOGCRS["ETRS89",
+          ENSEMBLE["European Terrestrial Reference System 1989 ensemble",
+              MEMBER["European Terrestrial Reference Frame 1989"],
+              MEMBER["European Terrestrial Reference Frame 1990"],
+              MEMBER["European Terrestrial Reference Frame 1991"],
+              MEMBER["European Terrestrial Reference Frame 1992"],
+              MEMBER["European Terrestrial Reference Frame 1993"],
+              MEMBER["European Terrestrial Reference Frame 1994"],
+              MEMBER["European Terrestrial Reference Frame 1996"],
+              MEMBER["European Terrestrial Reference Frame 1997"],
+              MEMBER["European Terrestrial Reference Frame 2000"],
+              MEMBER["European Terrestrial Reference Frame 2005"],
+              MEMBER["European Terrestrial Reference Frame 2014"],
+              MEMBER["European Terrestrial Reference Frame 2020"],
+              ELLIPSOID["GRS 1980",6378137,298.257222101,
+                  LENGTHUNIT["metre",1]],
+              ENSEMBLEACCURACY[0.1]],
+          PRIMEM["Greenwich",0,
+              ANGLEUNIT["degree",0.0174532925199433]],
+          ID["EPSG",4258]],
+      CONVERSION["Europe Conformal 2001",
+          METHOD["Lambert Conic Conformal (2SP)",
+              ID["EPSG",9802]],
+          PARAMETER["Latitude of false origin",52,
+              ANGLEUNIT["degree",0.0174532925199433],
+              ID["EPSG",8821]],
+          PARAMETER["Longitude of false origin",10,
+              ANGLEUNIT["degree",0.0174532925199433],
+              ID["EPSG",8822]],
+          PARAMETER["Latitude of 1st standard parallel",35,
+              ANGLEUNIT["degree",0.0174532925199433],
+              ID["EPSG",8823]],
+          PARAMETER["Latitude of 2nd standard parallel",65,
+              ANGLEUNIT["degree",0.0174532925199433],
+              ID["EPSG",8824]],
+          PARAMETER["Easting at false origin",4000000,
+              LENGTHUNIT["metre",1],
+              ID["EPSG",8826]],
+          PARAMETER["Northing at false origin",2800000,
+              LENGTHUNIT["metre",1],
+              ID["EPSG",8827]]],
+      CS[Cartesian,2],
+          AXIS["northing (N)",north,
+              ORDER[1],
+              LENGTHUNIT["metre",1]],
+          AXIS["easting (E)",east,
+              ORDER[2],
+              LENGTHUNIT["metre",1]],
+      USAGE[
+          SCOPE["Conformal mapping at scales of 1:500,000 and smaller."],
+          AREA["Europe - European Union (EU) countries and candidates. Europe - onshore and offshore: Albania; Andorra; Austria; Belgium; Bosnia and Herzegovina; Bulgaria; Croatia; Cyprus; Czechia; Denmark; Estonia; Faroe Islands; Finland; France; Germany; Gibraltar; Greece; Hungary; Iceland; Ireland; Italy; Kosovo; Latvia; Liechtenstein; Lithuania; Luxembourg; Malta; Monaco; Montenegro; Netherlands; North Macedonia; Norway including Svalbard and Jan Mayen; Poland; Portugal including Madeira and Azores; Romania; San Marino; Serbia; Slovakia; Slovenia; Spain including Canary Islands; Sweden; Switzerland; Türkiye (Turkey); United Kingdom (UK) including Channel Islands and Isle of Man; Vatican City State."],
+          BBOX[24.6,-35.58,84.73,44.83]],
+      ID["EPSG",3034]]
+  Data axis to CRS axis mapping: 2,1
+  Origin = (3684217.673899999819696,2702950.319999999832362)
+  Pixel Size = (50.010753693181783,-49.993288469750738)
+  Metadata:
+    AREA_OR_POINT=Area
+  Image Structure Metadata:
+    INTERLEAVE=BAND
+  Corner Coordinates:
+  Upper Left  ( 3684217.674, 2702950.320) (  5d20'16.45"E, 51d 0'14.31"N)
+  Lower Left  ( 3684217.674, 2632709.750) (  5d24' 8.43"E, 50d21' 4.91"N)
+  Upper Right ( 3754632.815, 2702950.320) (  6d22'32.10"E, 51d 2'26.55"N)
+  Lower Right ( 3754632.815, 2632709.750) (  6d25'32.63"E, 50d23'15.34"N)
+  Center      ( 3719425.244, 2667830.035) (  5d53' 7.40"E, 50d41'49.42"N)
+  Band 1 Block=1408x1 Type=Float32, ColorInterp=Gray
+    NoData Value=nan
+  ```
+
+![ET_DTM_HC_2026_FINAL_50m.tif](Create%20GeoTIFF%20sample%20data/ET_DTM_HC_2026_FINAL_50m.tif)
+
+[tiff1.tif](Create%20GeoTIFF%20sample%20data/tiff1.tif)
+
+- Tiff2
+
+
+  ```
+  Driver: GTiff/GeoTIFF
+  Files: tiff2.tiff
+  Size is 1114, 1035
+  Coordinate System is:
+  PROJCRS["ETRS89-extended / LCC Europe",
+      BASEGEOGCRS["ETRS89",
+          ENSEMBLE["European Terrestrial Reference System 1989 ensemble",
+              MEMBER["European Terrestrial Reference Frame 1989"],
+              MEMBER["European Terrestrial Reference Frame 1990"],
+              MEMBER["European Terrestrial Reference Frame 1991"],
+              MEMBER["European Terrestrial Reference Frame 1992"],
+              MEMBER["European Terrestrial Reference Frame 1993"],
+              MEMBER["European Terrestrial Reference Frame 1994"],
+              MEMBER["European Terrestrial Reference Frame 1996"],
+              MEMBER["European Terrestrial Reference Frame 1997"],
+              MEMBER["European Terrestrial Reference Frame 2000"],
+              MEMBER["European Terrestrial Reference Frame 2005"],
+              MEMBER["European Terrestrial Reference Frame 2014"],
+              MEMBER["European Terrestrial Reference Frame 2020"],
+              ELLIPSOID["GRS 1980",6378137,298.257222101,
+                  LENGTHUNIT["metre",1]],
+              ENSEMBLEACCURACY[0.1]],
+          PRIMEM["Greenwich",0,
+              ANGLEUNIT["degree",0.0174532925199433]],
+          ID["EPSG",4258]],
+      CONVERSION["Europe Conformal 2001",
+          METHOD["Lambert Conic Conformal (2SP)",
+              ID["EPSG",9802]],
+          PARAMETER["Latitude of false origin",52,
+              ANGLEUNIT["degree",0.0174532925199433],
+              ID["EPSG",8821]],
+          PARAMETER["Longitude of false origin",10,
+              ANGLEUNIT["degree",0.0174532925199433],
+              ID["EPSG",8822]],
+          PARAMETER["Latitude of 1st standard parallel",35,
+              ANGLEUNIT["degree",0.0174532925199433],
+              ID["EPSG",8823]],
+          PARAMETER["Latitude of 2nd standard parallel",65,
+              ANGLEUNIT["degree",0.0174532925199433],
+              ID["EPSG",8824]],
+          PARAMETER["Easting at false origin",4000000,
+              LENGTHUNIT["metre",1],
+              ID["EPSG",8826]],
+          PARAMETER["Northing at false origin",2800000,
+              LENGTHUNIT["metre",1],
+              ID["EPSG",8827]]],
+      CS[Cartesian,2],
+          AXIS["northing (N)",north,
+              ORDER[1],
+              LENGTHUNIT["metre",1]],
+          AXIS["easting (E)",east,
+              ORDER[2],
+              LENGTHUNIT["metre",1]],
+      USAGE[
+          SCOPE["Conformal mapping at scales of 1:500,000 and smaller."],
+          AREA["Europe - European Union (EU) countries and candidates. Europe - onshore and offshore: Albania; Andorra; Austria; Belgium; Bosnia and Herzegovina; Bulgaria; Croatia; Cyprus; Czechia; Denmark; Estonia; Faroe Islands; Finland; France; Germany; Gibraltar; Greece; Hungary; Iceland; Ireland; Italy; Kosovo; Latvia; Liechtenstein; Lithuania; Luxembourg; Malta; Monaco; Montenegro; Netherlands; North Macedonia; Norway including Svalbard and Jan Mayen; Poland; Portugal including Madeira and Azores; Romania; San Marino; Serbia; Slovakia; Slovenia; Spain including Canary Islands; Sweden; Switzerland; Türkiye (Turkey); United Kingdom (UK) including Channel Islands and Isle of Man; Vatican City State."],
+          BBOX[24.6,-35.58,84.73,44.83]],
+      ID["EPSG",3034]]
+  Data axis to CRS axis mapping: 2,1
+  Origin = (3711183.000000000000000,2678182.140484739560634)
+  Pixel Size = (15.616696588868940,-15.616696588868940)
+  Metadata:
+    TIFFTAG_XRESOLUTION=72
+    TIFFTAG_YRESOLUTION=72
+    TIFFTAG_RESOLUTIONUNIT=2 (pixels/inch)
+    AREA_OR_POINT=Area
+  Image Structure Metadata:
+    COMPRESSION=LZW
+    INTERLEAVE=PIXEL
+  Corner Coordinates:
+  Upper Left  ( 3711183.000, 2678182.140) (  5d45'21.85"E, 50d47'20.19"N)
+  Lower Left  ( 3711183.000, 2662018.860) (  5d46'10.74"E, 50d38'19.39"N)
+  Upper Right ( 3728580.000, 2678182.140) (  6d 0'40.29"E, 50d47'52.65"N)
+  Lower Right ( 3728580.000, 2662018.860) (  6d 1'26.26"E, 50d38'51.75"N)
+  Center      ( 3719881.500, 2670100.500) (  5d53'24.78"E, 50d43' 6.25"N)
+  Band 1 Block=1114x941 Type=Byte, ColorInterp=Red
+    Mask Flags: PER_DATASET ALPHA 
+  Band 2 Block=1114x941 Type=Byte, ColorInterp=Green
+    Mask Flags: PER_DATASET ALPHA 
+  Band 3 Block=1114x941 Type=Byte, ColorInterp=Blue
+    Mask Flags: PER_DATASET ALPHA 
+  Band 4 Block=1114x941 Type=Byte, ColorInterp=Alpha
+  ```
+
+![tiff2.tiff](Create%20GeoTIFF%20sample%20data/tiff2.tiff)
+
+[tiff2.tiff](Create%20GeoTIFF%20sample%20data/tiff2%201.tiff)
+
+- Tiff3 (larger one)
+
+
+  ```
+  Driver: GTiff/GeoTIFF
+  Files: tiff3.tiff
+  Size is 12699, 11797
+  Coordinate System is:
+  PROJCRS["ETRS89-extended / LCC Europe",
+      BASEGEOGCRS["ETRS89",
+          ENSEMBLE["European Terrestrial Reference System 1989 ensemble",
+              MEMBER["European Terrestrial Reference Frame 1989"],
+              MEMBER["European Terrestrial Reference Frame 1990"],
+              MEMBER["European Terrestrial Reference Frame 1991"],
+              MEMBER["European Terrestrial Reference Frame 1992"],
+              MEMBER["European Terrestrial Reference Frame 1993"],
+              MEMBER["European Terrestrial Reference Frame 1994"],
+              MEMBER["European Terrestrial Reference Frame 1996"],
+              MEMBER["European Terrestrial Reference Frame 1997"],
+              MEMBER["European Terrestrial Reference Frame 2000"],
+              MEMBER["European Terrestrial Reference Frame 2005"],
+              MEMBER["European Terrestrial Reference Frame 2014"],
+              MEMBER["European Terrestrial Reference Frame 2020"],
+              ELLIPSOID["GRS 1980",6378137,298.257222101,
+                  LENGTHUNIT["metre",1]],
+              ENSEMBLEACCURACY[0.1]],
+          PRIMEM["Greenwich",0,
+              ANGLEUNIT["degree",0.0174532925199433]],
+          ID["EPSG",4258]],
+      CONVERSION["Europe Conformal 2001",
+          METHOD["Lambert Conic Conformal (2SP)",
+              ID["EPSG",9802]],
+          PARAMETER["Latitude of false origin",52,
+              ANGLEUNIT["degree",0.0174532925199433],
+              ID["EPSG",8821]],
+          PARAMETER["Longitude of false origin",10,
+              ANGLEUNIT["degree",0.0174532925199433],
+              ID["EPSG",8822]],
+          PARAMETER["Latitude of 1st standard parallel",35,
+              ANGLEUNIT["degree",0.0174532925199433],
+              ID["EPSG",8823]],
+          PARAMETER["Latitude of 2nd standard parallel",65,
+              ANGLEUNIT["degree",0.0174532925199433],
+              ID["EPSG",8824]],
+          PARAMETER["Easting at false origin",4000000,
+              LENGTHUNIT["metre",1],
+              ID["EPSG",8826]],
+          PARAMETER["Northing at false origin",2800000,
+              LENGTHUNIT["metre",1],
+              ID["EPSG",8827]]],
+      CS[Cartesian,2],
+          AXIS["northing (N)",north,
+              ORDER[1],
+              LENGTHUNIT["metre",1]],
+          AXIS["easting (E)",east,
+              ORDER[2],
+              LENGTHUNIT["metre",1]],
+      USAGE[
+          SCOPE["Conformal mapping at scales of 1:500,000 and smaller."],
+          AREA["Europe - European Union (EU) countries and candidates. Europe - onshore and offshore: Albania; Andorra; Austria; Belgium; Bosnia and Herzegovina; Bulgaria; Croatia; Cyprus; Czechia; Denmark; Estonia; Faroe Islands; Finland; France; Germany; Gibraltar; Greece; Hungary; Iceland; Ireland; Italy; Kosovo; Latvia; Liechtenstein; Lithuania; Luxembourg; Malta; Monaco; Montenegro; Netherlands; North Macedonia; Norway including Svalbard and Jan Mayen; Poland; Portugal including Madeira and Azores; Romania; San Marino; Serbia; Slovakia; Slovenia; Spain including Canary Islands; Sweden; Switzerland; Türkiye (Turkey); United Kingdom (UK) including Channel Islands and Isle of Man; Vatican City State."],
+          BBOX[24.6,-35.58,84.73,44.83]],
+      ID["EPSG",3034]]
+  Data axis to CRS axis mapping: 2,1
+  Origin = (3711183.000000000000000,2678181.152374202851206)
+  Pixel Size = (1.369950389794472,-1.369950389794472)
+  Metadata:
+    TIFFTAG_XRESOLUTION=100
+    TIFFTAG_YRESOLUTION=100
+    TIFFTAG_RESOLUTIONUNIT=2 (pixels/inch)
+    AREA_OR_POINT=Area
+  Image Structure Metadata:
+    COMPRESSION=LZW
+    INTERLEAVE=PIXEL
+  Corner Coordinates:
+  Upper Left  ( 3711183.000, 2678181.152) (  5d45'21.85"E, 50d47'20.16"N)
+  Lower Left  ( 3711183.000, 2662019.848) (  5d46'10.74"E, 50d38'19.42"N)
+  Upper Right ( 3728580.000, 2678181.152) (  6d 0'40.29"E, 50d47'52.62"N)
+  Lower Right ( 3728580.000, 2662019.848) (  6d 1'26.25"E, 50d38'51.78"N)
+  Center      ( 3719881.500, 2670100.500) (  5d53'24.78"E, 50d43' 6.25"N)
+  Band 1 Block=12699x82 Type=Byte, ColorInterp=Red
+    Mask Flags: PER_DATASET ALPHA 
+  Band 2 Block=12699x82 Type=Byte, ColorInterp=Green
+    Mask Flags: PER_DATASET ALPHA 
+  Band 3 Block=12699x82 Type=Byte, ColorInterp=Blue
+    Mask Flags: PER_DATASET ALPHA 
+  Band 4 Block=12699x82 Type=Byte, ColorInterp=Alpha
+  ```
+
+[tiff3.tiff](Create%20GeoTIFF%20sample%20data/tiff3.tiff)
+
+#### Test Cases:
+
+- 1
+
+  [rasterio-rgb-byte.tif](Create%20GeoTIFF%20sample%20data/rasterio-rgb-byte.tif)
+
+    - 3-band RGB byte imagery
+    - `PixelIsArea`
+    - EPSG-coded CRS
+    - Uncompressed data
+
+- 2
+
+  [geotiff-testdata-gadas.tif](Create%20GeoTIFF%20sample%20data/geotiff-testdata-gadas.tif)
+
+    - 4-band RGBA byte imagery
+
+- 3
+
+  [geotiff-testdata-geogtowgs84.tif](Create%20GeoTIFF%20sample%20data/geotiff-testdata-geogtowgs84.tif)
+
+    - Palette raster with `ColorMap`
+    - PackBits compression
+    - `GeogTOWGS84GeoKey` datum transform
+
+- 4
+
+  [osgeo-gdal-cea.tif](Create%20GeoTIFF%20sample%20data/osgeo-gdal-cea.tif)
+
+    - Single-band byte grayscale
+    - Stripped layout
+    - User-defined CRS
+
+- 5
+
+  [osgeo-usgs-i30dem.tif](Create%20GeoTIFF%20sample%20data/osgeo-usgs-i30dem.tif)
+
+    - Signed 16-bit DEM
+    - `PixelIsPoint`
+
+- 6
+
+  [geotiff-testdata-lisbon-elevation.tif](Create%20GeoTIFF%20sample%20data/geotiff-testdata-lisbon-elevation.tif)
+
+    - Float32 DEM / scientific raster
+
+- 7
+
+  [geotiff-testdata-wind-direction.tif](Create%20GeoTIFF%20sample%20data/geotiff-testdata-wind-direction.tif)
+
+    - LZW compression
+
+- 8
+
+  [geotiff-testdata-vanderford-cog.tif](Create%20GeoTIFF%20sample%20data/geotiff-testdata-vanderford-cog.tif)
+
+    - Deflate compression
+    - Tiled layout
+    - Multiple IFDs / internal overviews
+
+#### File Descriptions
+
+| File                                    | Variety                                  | Key traits                                                   | CRS / georeferencing                                         | Source                                                       |
+| --------------------------------------- | ---------------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------ | ------------------------------------------------------------ |
+| `rasterio-rgb-byte.tif`                 | RGB imagery                              | 791x718, 3 x UInt8, RGB, uncompressed, stripped              | EPSG:32618, WGS 84 / UTM zone 18N, PixelIsArea               | [https://raw.githubusercontent.com/rasterio/rasterio/main/tests/data/RGB.byte.tif](https://raw.githubusercontent.com/rasterio/rasterio/main/tests/data/RGB.byte.tif) |
+| `geotiff-testdata-gadas.tif`            | RGBA imagery                             | 968x475, 4 x UInt8, RGB + unassociated alpha, uncompressed, stripped | user-defined Web Mercator / WGS84-style CRS text, PixelIsArea | [https://raw.githubusercontent.com/GeoTIFF/test-data/main/files/gadas.tif](https://raw.githubusercontent.com/GeoTIFF/test-data/main/files/gadas.tif) |
+| `geotiff-testdata-geogtowgs84.tif`      | Palette + datum transform                | 101x101, UInt8 palette, PackBits, stripped, `ColorMap` present | user-defined geographic CRS with `GeogTOWGS84`transform, PixelIsArea | [https://raw.githubusercontent.com/GeoTIFF/test-data/main/files/GeogToWGS84GeoKey5.tif](https://raw.githubusercontent.com/GeoTIFF/test-data/main/files/GeogToWGS84GeoKey5.tif) |
+| `geotiff-testdata-lisbon-elevation.tif` | Float32 elevation                        | 547x421, 1 x Float32, uncompressed, stripped                 | EPSG:4326 / WGS84, PixelIsArea                               | [https://raw.githubusercontent.com/GeoTIFF/test-data/main/files/LisbonElevation.tif](https://raw.githubusercontent.com/GeoTIFF/test-data/main/files/LisbonElevation.tif) |
+| `osgeo-usgs-i30dem.tif`                 | Signed 16-bit DEM                        | 1479x1863, 1 x Int16, uncompressed, stripped                 | EPSG:26710, UTM Zone 10 / NAD27, PixelIsPoint                | [https://download.osgeo.org/geotiff/samples/usgs/i30dem.tif](https://download.osgeo.org/geotiff/samples/usgs/i30dem.tif) |
+| `geotiff-testdata-vanderford-cog.tif`   | COG-style tiled Float32 raster           | 2581x1998 main IFD, 1 x Float32, Deflate, 512x512 tiled, 4 IFDs with internal overviews | EPSG:3031, Antarctic Polar Stereographic, PixelIsPoint       | [https://raw.githubusercontent.com/GeoTIFF/test-data/main/files/GA4886_VanderfordGlacier_2022_EGM2008_64m-epsg3031.cog](https://raw.githubusercontent.com/GeoTIFF/test-data/main/files/GA4886_VanderfordGlacier_2022_EGM2008_64m-epsg3031.cog) |
+| `geotiff-testdata-wind-direction.tif`   | LZW Float32 scientific raster            | 232x193, 1 x Float32, LZW, stripped                          | EPSG:4326 / WGS84, PixelIsArea                               | [https://raw.githubusercontent.com/GeoTIFF/test-data/main/files/wind_direction.tif](https://raw.githubusercontent.com/GeoTIFF/test-data/main/files/wind_direction.tif) |
+| `osgeo-gdal-cea.tif`                    | Byte grayscale + user-defined projection | 514x515, 1 x UInt8, uncompressed, stripped                   | user-defined Cylindrical Equal Area over NAD27, PixelIsArea  | [https://download.osgeo.org/geotiff/samples/gdal_eg/cea.tif](https://download.osgeo.org/geotiff/samples/gdal_eg/cea.tif) |
+| `geotiff-testdata-dom1-float32.tif`     | Float32 projected raster                 | 1000x1000, 1 x Float32, uncompressed, stripped               |                                                              |                                                              |EPSG:25832, ETRS89 / UTM zone 32N, PixelIsArea[https://raw.githubusercontent.com/GeoTIFF/test-data/main/files/dom1_32_356_5699_1_nw_2020.tif](https://raw.githubusercontent.com/GeoTIFF/test-data/main/files/dom1_32_356_5699_1_nw_2020.tif)

--- a/tests/test_io/test_raster/test_geotiff_I.py
+++ b/tests/test_io/test_raster/test_geotiff_I.py
@@ -240,7 +240,8 @@ def test_read_soricom_geotiff():
     devops_path = os.getenv("TERRA_PATH_DEVOPS")
     tif_path = os.path.join(devops_path, "raster/dem.tif")
     # foo = "/home/leguark/Downloads/dem.tif"
-    crop_to_extent = [441850.0, 4584200.0, 442350.0, 4584400.0]
+    # crop_to_extent = [441850.0, 4584200.0, 442350.0, 4584400.0]
+    crop_to_extent = [4441850.0, 4588200.0, 4442350.0, 4588400.0]
 
     # Plot directly from rasterio for comparison
     fig_raw = _raw_rasterio_plot(tif_path, 'soricomDEM10m', crop_to_extent=crop_to_extent)

--- a/tests/test_io/test_raster/test_geotiff_I.py
+++ b/tests/test_io/test_raster/test_geotiff_I.py
@@ -64,6 +64,21 @@ def test_rasterio_dataset_to_structured_data_projects_geographic_coords_to_metri
     assert np.diff(y)[0] > 10_000
 
 
+def test_rasterio_dataset_to_structured_data_masks_unsigned_integer_max_without_nodata():
+    data = np.array([[1, np.iinfo(np.uint32).max], [3, 4]], dtype=np.uint32)
+    transform = from_origin(100, 220, 10, 20)
+
+    with _memory_raster(data, transform) as memory_file:
+        with memory_file.open() as dataset:
+            struct = rasterio_dataset_to_structured_data(dataset)
+
+    topography = struct.data['topography']
+    np.testing.assert_allclose(
+        topography.values,
+        np.array([[3, 1], [4, np.nan]], dtype=float)
+    )
+
+
 def _raw_rasterio_plot(tif_path: str, title: str):
     """Plot a GeoTIFF directly via rasterio for comparison."""
     with rasterio.open(tif_path) as src:

--- a/tests/test_io/test_raster/test_geotiff_I.py
+++ b/tests/test_io/test_raster/test_geotiff_I.py
@@ -18,18 +18,24 @@ pytestmark = pytest.mark.read_geospatial
 
 
 def _memory_raster(data, transform, crs='EPSG:3857', nodata=None):
+    count = 1 if data.ndim == 2 else data.shape[0]
+    height = data.shape[0] if data.ndim == 2 else data.shape[1]
+    width = data.shape[1] if data.ndim == 2 else data.shape[2]
     memory_file = MemoryFile()
     with memory_file.open(
             driver='GTiff',
-            height=data.shape[0],
-            width=data.shape[1],
-            count=1,
+            height=height,
+            width=width,
+            count=count,
             dtype=data.dtype,
             transform=transform,
             crs=crs,
             nodata=nodata
     ) as dataset:
-        dataset.write(data, 1)
+        if data.ndim == 2:
+            dataset.write(data, 1)
+        else:
+            dataset.write(data)
     return memory_file
 
 
@@ -79,6 +85,42 @@ def test_rasterio_dataset_to_structured_data_masks_unsigned_integer_max_without_
     )
 
 
+def test_rasterio_dataset_to_structured_data_can_read_requested_band():
+    data = np.array([
+            [[0, np.iinfo(np.uint32).max], [0, np.iinfo(np.uint32).max]],
+            [[10, 20], [30, 40]]
+    ], dtype=np.uint32)
+    transform = from_origin(100, 220, 10, 20)
+
+    with _memory_raster(data, transform) as memory_file:
+        with memory_file.open() as dataset:
+            struct = rasterio_dataset_to_structured_data(dataset, band=2)
+
+    topography = struct.data['topography']
+    np.testing.assert_allclose(
+        topography.values,
+        np.array([[30, 10], [40, 20]], dtype=float)
+    )
+
+
+def test_rasterio_dataset_to_structured_data_auto_selects_richest_band():
+    data = np.array([
+            [[0, np.iinfo(np.uint32).max], [0, np.iinfo(np.uint32).max]],
+            [[10, 20], [30, 40]]
+    ], dtype=np.uint32)
+    transform = from_origin(100, 220, 10, 20)
+
+    with _memory_raster(data, transform) as memory_file:
+        with memory_file.open() as dataset:
+            struct = rasterio_dataset_to_structured_data(dataset)
+
+    topography = struct.data['topography']
+    np.testing.assert_allclose(
+        topography.values,
+        np.array([[30, 10], [40, 20]], dtype=float)
+    )
+
+
 def _raw_rasterio_plot(tif_path: str, title: str):
     """Plot a GeoTIFF directly via rasterio for comparison."""
     with rasterio.open(tif_path) as src:
@@ -104,7 +146,7 @@ def test_read_lisbon_elevation_geotiff():
     # Plot directly from rasterio for comparison
     fig_raw = _raw_rasterio_plot(tif_path, 'wind-direction')
     fig_raw.show()
-    
+
     struct = read_structured_topography(tif_path)
     replace_outliers(struct, 'topography', 0.99)
     sg = StructuredGrid(struct)
@@ -140,13 +182,12 @@ def test_read_wind_direction_geotiff():
 def test_read_soricom_geotiff():
     """Import soricomDEM10m.tif and compare raw vs subsurface pipeline plots."""
     devops_path = os.getenv("TERRA_PATH_DEVOPS")
-    tif_path = os.path.join(devops_path, "raster/soricomDEM10m.tif")
+    tif_path = os.path.join(devops_path, "raster/dem.tif")
+    # foo = "/home/leguark/Downloads/dem.tif"
 
     # Plot directly from rasterio for comparison
     fig_raw = _raw_rasterio_plot(tif_path, 'soricomDEM10m')
     fig_raw.show()
-
-    # Plot via subsurface pipeline
     struct = read_structured_topography(tif_path)
     # replace_outliers(struct, 'topography', 0.99)
     sg = StructuredGrid(struct)

--- a/tests/test_io/test_raster/test_geotiff_I.py
+++ b/tests/test_io/test_raster/test_geotiff_I.py
@@ -5,7 +5,9 @@ import numpy as np
 import pytest
 import rasterio
 from rasterio.io import MemoryFile
+from rasterio.plot import plotting_extent
 from rasterio.transform import from_origin
+from matplotlib.patches import Rectangle
 
 from tests.conftest import RequirementsLevel
 from subsurface import StructuredGrid
@@ -121,16 +123,70 @@ def test_rasterio_dataset_to_structured_data_auto_selects_richest_band():
     )
 
 
-def _raw_rasterio_plot(tif_path: str, title: str):
+def test_rasterio_dataset_to_structured_data_crops_to_extent():
+    data = np.arange(20, dtype=np.float32).reshape(4, 5)
+    transform = from_origin(100, 240, 10, 10)
+
+    with _memory_raster(data, transform) as memory_file:
+        with memory_file.open() as dataset:
+            struct = rasterio_dataset_to_structured_data(
+                dataset,
+                crop_to_extent=[110, 210, 140, 230]
+            )
+
+    topography = struct.data['topography']
+    np.testing.assert_allclose(topography.coords['x'], [115, 125, 135])
+    np.testing.assert_allclose(topography.coords['y'], [215, 225])
+    np.testing.assert_allclose(
+        topography.values,
+        np.array([[11, 6], [12, 7], [13, 8]], dtype=np.float32)
+    )
+
+
+def test_rasterio_dataset_to_structured_data_clips_crop_to_raster_bounds():
+    data = np.arange(20, dtype=np.float32).reshape(4, 5)
+    transform = from_origin(100, 240, 10, 10)
+
+    with _memory_raster(data, transform) as memory_file:
+        with memory_file.open() as dataset:
+            struct = rasterio_dataset_to_structured_data(
+                dataset,
+                crop_to_extent=[90, 215, 125, 250]
+            )
+
+    topography = struct.data['topography']
+    np.testing.assert_allclose(topography.coords['x'], [105, 115, 125])
+    np.testing.assert_allclose(topography.coords['y'], [215, 225, 235])
+    np.testing.assert_allclose(
+        topography.values,
+        np.array([[10, 5, 0], [11, 6, 1], [12, 7, 2]], dtype=np.float32)
+    )
+
+
+def _raw_rasterio_plot(tif_path: str, title: str, crop_to_extent=None):
     """Plot a GeoTIFF directly via rasterio for comparison."""
     with rasterio.open(tif_path) as src:
-        data = np.fliplr(src.read(1).T)
+        data = src.read(1)
+        extent = plotting_extent(src)
     fig, ax = plt.subplots(figsize=(10, 8))
-    im = ax.imshow(data, cmap='terrain', origin='lower')
+    im = ax.imshow(data, cmap='terrain', extent=extent)
+    if crop_to_extent is not None:
+        min_x, min_y, max_x, max_y = crop_to_extent
+        crop_rectangle = Rectangle(
+            (min_x, min_y),
+            max_x - min_x,
+            max_y - min_y,
+            fill=False,
+            edgecolor='red',
+            linewidth=2,
+            label='crop_to_extent'
+        )
+        ax.add_patch(crop_rectangle)
+        ax.legend(loc='upper right')
     ax.set_title(f'{title} (raw rasterio)', fontsize=12)
     fig.colorbar(im, ax=ax, label='Elevation (m)')
-    ax.set_xlabel('x (pixels)')
-    ax.set_ylabel('y (pixels)')
+    ax.set_xlabel('x')
+    ax.set_ylabel('y')
     fig.tight_layout()
     return fig
 
@@ -184,15 +240,16 @@ def test_read_soricom_geotiff():
     devops_path = os.getenv("TERRA_PATH_DEVOPS")
     tif_path = os.path.join(devops_path, "raster/dem.tif")
     # foo = "/home/leguark/Downloads/dem.tif"
+    crop_to_extent = [441850.0, 4584200.0, 442350.0, 4584400.0]
 
     # Plot directly from rasterio for comparison
-    fig_raw = _raw_rasterio_plot(tif_path, 'soricomDEM10m')
+    fig_raw = _raw_rasterio_plot(tif_path, 'soricomDEM10m', crop_to_extent=crop_to_extent)
     fig_raw.show()
     struct = read_structured_topography(
         path=tif_path,
-        crop_to_extent=[4441850.0, 4588200.0, 4442350.0, 4588400.0]
+        crop_to_extent=crop_to_extent
     )
     # replace_outliers(struct, 'topography', 0.99)
     sg = StructuredGrid(struct)
     s = to_pyvista_grid(sg, data_order='C', data_set_name='topography')
-    pv_plot([s], image_2d=True)
+    pv_plot([s], image_2d=False)

--- a/tests/test_io/test_raster/test_geotiff_I.py
+++ b/tests/test_io/test_raster/test_geotiff_I.py
@@ -1,0 +1,25 @@
+import os
+
+import pytest
+
+from tests.conftest import RequirementsLevel
+from subsurface import StructuredGrid
+from subsurface.modules.reader import read_structured_topography
+from subsurface.core.utils.utils_core import replace_outliers
+from subsurface.modules.visualization import to_pyvista_grid, pv_plot
+
+pytestmark = pytest.mark.read_geospatial
+
+
+@pytest.mark.skipif(
+    condition=(RequirementsLevel.READ_GEOSPATIAL) not in RequirementsLevel.REQUIREMENT_LEVEL_TO_TEST(),
+    reason="Need to set the READ_GEOSPATIAL variable to run this test"
+)
+def test_read_lisbon_elevation_geotiff():
+    devops_path = os.getenv("TERRA_PATH_DEVOPS")
+    tif_path = os.path.join(devops_path, "raster/geotiff-testdata-lisbon-elevation.tif")
+    struct = read_structured_topography(tif_path)
+    replace_outliers(struct, 'topography', 0.99)
+    sg = StructuredGrid(struct)
+    s = to_pyvista_grid(sg, data_order='C', data_set_name='topography')
+    pv_plot([s], image_2d=False)

--- a/tests/test_io/test_raster/test_geotiff_I.py
+++ b/tests/test_io/test_raster/test_geotiff_I.py
@@ -85,6 +85,11 @@ def _raw_rasterio_plot(tif_path: str, title: str):
 def test_read_lisbon_elevation_geotiff():
     devops_path = os.getenv("TERRA_PATH_DEVOPS")
     tif_path = os.path.join(devops_path, "raster/geotiff-testdata-lisbon-elevation.tif")
+
+    # Plot directly from rasterio for comparison
+    fig_raw = _raw_rasterio_plot(tif_path, 'wind-direction')
+    fig_raw.show()
+    
     struct = read_structured_topography(tif_path)
     replace_outliers(struct, 'topography', 0.99)
     sg = StructuredGrid(struct)
@@ -111,3 +116,24 @@ def test_read_wind_direction_geotiff():
     sg = StructuredGrid(struct)
     s = to_pyvista_grid(sg, data_order='C', data_set_name='topography')
     pv_plot([s], image_2d=False)
+
+
+@pytest.mark.skipif(
+    condition=(RequirementsLevel.READ_GEOSPATIAL) not in RequirementsLevel.REQUIREMENT_LEVEL_TO_TEST(),
+    reason="Need to set the READ_GEOSPATIAL variable to run this test"
+)
+def test_read_soricom_geotiff():
+    """Import soricomDEM10m.tif and compare raw vs subsurface pipeline plots."""
+    devops_path = os.getenv("TERRA_PATH_DEVOPS")
+    tif_path = os.path.join(devops_path, "raster/soricomDEM10m.tif")
+
+    # Plot directly from rasterio for comparison
+    fig_raw = _raw_rasterio_plot(tif_path, 'soricomDEM10m')
+    fig_raw.show()
+
+    # Plot via subsurface pipeline
+    struct = read_structured_topography(tif_path)
+    # replace_outliers(struct, 'topography', 0.99)
+    sg = StructuredGrid(struct)
+    s = to_pyvista_grid(sg, data_order='C', data_set_name='topography')
+    pv_plot([s], image_2d=True)

--- a/tests/test_io/test_raster/test_geotiff_I.py
+++ b/tests/test_io/test_raster/test_geotiff_I.py
@@ -1,6 +1,9 @@
 import os
 
+import matplotlib.pyplot as plt
+import numpy as np
 import pytest
+import rasterio
 
 from tests.conftest import RequirementsLevel
 from subsurface import StructuredGrid
@@ -11,6 +14,20 @@ from subsurface.modules.visualization import to_pyvista_grid, pv_plot
 pytestmark = pytest.mark.read_geospatial
 
 
+def _raw_rasterio_plot(tif_path: str, title: str):
+    """Plot a GeoTIFF directly via rasterio for comparison."""
+    with rasterio.open(tif_path) as src:
+        data = np.fliplr(src.read(1).T)
+    fig, ax = plt.subplots(figsize=(10, 8))
+    im = ax.imshow(data, cmap='terrain', origin='lower')
+    ax.set_title(f'{title} (raw rasterio)', fontsize=12)
+    fig.colorbar(im, ax=ax, label='Elevation (m)')
+    ax.set_xlabel('x (pixels)')
+    ax.set_ylabel('y (pixels)')
+    fig.tight_layout()
+    return fig
+
+
 @pytest.mark.skipif(
     condition=(RequirementsLevel.READ_GEOSPATIAL) not in RequirementsLevel.REQUIREMENT_LEVEL_TO_TEST(),
     reason="Need to set the READ_GEOSPATIAL variable to run this test"
@@ -18,6 +35,27 @@ pytestmark = pytest.mark.read_geospatial
 def test_read_lisbon_elevation_geotiff():
     devops_path = os.getenv("TERRA_PATH_DEVOPS")
     tif_path = os.path.join(devops_path, "raster/geotiff-testdata-lisbon-elevation.tif")
+    struct = read_structured_topography(tif_path)
+    replace_outliers(struct, 'topography', 0.99)
+    sg = StructuredGrid(struct)
+    s = to_pyvista_grid(sg, data_order='C', data_set_name='topography')
+    pv_plot([s], image_2d=False)
+
+
+@pytest.mark.skipif(
+    condition=(RequirementsLevel.READ_GEOSPATIAL) not in RequirementsLevel.REQUIREMENT_LEVEL_TO_TEST(),
+    reason="Need to set the READ_GEOSPATIAL variable to run this test"
+)
+def test_read_wind_direction_geotiff():
+    """Compare raw rasterio plot vs subsurface pipeline for wind_direction.tif."""
+    devops_path = os.getenv("TERRA_PATH_DEVOPS")
+    tif_path = os.path.join(devops_path, "raster/geotiff-testdata-wind-direction.tif")
+
+    # Plot directly from rasterio for comparison
+    fig_raw = _raw_rasterio_plot(tif_path, 'wind-direction')
+    fig_raw.show()
+
+    # Plot via subsurface pipeline
     struct = read_structured_topography(tif_path)
     replace_outliers(struct, 'topography', 0.99)
     sg = StructuredGrid(struct)

--- a/tests/test_io/test_raster/test_geotiff_I.py
+++ b/tests/test_io/test_raster/test_geotiff_I.py
@@ -188,7 +188,10 @@ def test_read_soricom_geotiff():
     # Plot directly from rasterio for comparison
     fig_raw = _raw_rasterio_plot(tif_path, 'soricomDEM10m')
     fig_raw.show()
-    struct = read_structured_topography(tif_path)
+    struct = read_structured_topography(
+        path=tif_path,
+        crop_to_extent=[4441850.0, 4588200.0, 4442350.0, 4588400.0]
+    )
     # replace_outliers(struct, 'topography', 0.99)
     sg = StructuredGrid(struct)
     s = to_pyvista_grid(sg, data_order='C', data_set_name='topography')

--- a/tests/test_io/test_raster/test_geotiff_I.py
+++ b/tests/test_io/test_raster/test_geotiff_I.py
@@ -4,14 +4,64 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 import rasterio
+from rasterio.io import MemoryFile
+from rasterio.transform import from_origin
 
 from tests.conftest import RequirementsLevel
 from subsurface import StructuredGrid
 from subsurface.modules.reader import read_structured_topography
+from subsurface.modules.reader.topography.topo_core import rasterio_dataset_to_structured_data
 from subsurface.core.utils.utils_core import replace_outliers
 from subsurface.modules.visualization import to_pyvista_grid, pv_plot
 
 pytestmark = pytest.mark.read_geospatial
+
+
+def _memory_raster(data, transform, crs='EPSG:3857', nodata=None):
+    memory_file = MemoryFile()
+    with memory_file.open(
+            driver='GTiff',
+            height=data.shape[0],
+            width=data.shape[1],
+            count=1,
+            dtype=data.dtype,
+            transform=transform,
+            crs=crs,
+            nodata=nodata
+    ) as dataset:
+        dataset.write(data, 1)
+    return memory_file
+
+
+def test_rasterio_dataset_to_structured_data_uses_pixel_centers_and_masks_nodata():
+    data = np.array([[1, -9999, 3], [4, 5, 6]], dtype=np.float32)
+    transform = from_origin(100, 220, 10, 20)
+
+    with _memory_raster(data, transform, nodata=-9999) as memory_file:
+        with memory_file.open() as dataset:
+            struct = rasterio_dataset_to_structured_data(dataset)
+
+    topography = struct.data['topography']
+    np.testing.assert_allclose(topography.coords['x'], [105, 115, 125])
+    np.testing.assert_allclose(topography.coords['y'], [190, 210])
+    np.testing.assert_allclose(
+        topography.values,
+        np.array([[4, 1], [5, np.nan], [6, 3]], dtype=np.float32)
+    )
+
+
+def test_rasterio_dataset_to_structured_data_projects_geographic_coords_to_metric():
+    data = np.ones((2, 2), dtype=np.float32)
+    transform = from_origin(-9.2, 38.8, 0.1, 0.1)
+
+    with _memory_raster(data, transform, crs='EPSG:4326') as memory_file:
+        with memory_file.open() as dataset:
+            struct = rasterio_dataset_to_structured_data(dataset)
+
+    x = struct.data.coords['x'].values
+    y = struct.data.coords['y'].values
+    assert np.diff(x)[0] > 8_000
+    assert np.diff(y)[0] > 10_000
 
 
 def _raw_rasterio_plot(tif_path: str, title: str):
@@ -57,7 +107,7 @@ def test_read_wind_direction_geotiff():
 
     # Plot via subsurface pipeline
     struct = read_structured_topography(tif_path)
-    replace_outliers(struct, 'topography', 0.99)
+    # replace_outliers(struct, 'topography', 0.99)
     sg = StructuredGrid(struct)
     s = to_pyvista_grid(sg, data_order='C', data_set_name='topography')
     pv_plot([s], image_2d=False)


### PR DESCRIPTION
Geotiff files

[TEST] Add GeoTIFF test data and associated raster tests

- Introduced GeoTIFF sample data for raster testing.
- Added `test_geotiff_I.py` to validate handling of various GeoTIFF formats and coordinate systems.
- Included detailed file descriptions and traits in `TIF_TEST_DATA_DESCRIPTION.md` for reference.

[TEST] Add test for reading Lisbon elevation GeoTIFF with visualization

- Introduced `test_read_lisbon_elevation_geotiff` to validate GeoTIFF reading and topography processing.
- Added outlier replacement and 3D visualization using `pv_plot` for elevation data.

[TEST] Add GeoTIFF test for wind direction with raw rasterio comparison

- Introduced `_raw_rasterio_plot` for direct visualization of GeoTIFF data using rasterio.
- Added `test_read_wind_direction_geotiff` to compare rasterio output with subsurface pipeline results.
- Included 3D topography visualization with `pv_plot`.

[ENH] Enhance raster processing and add tests for pixel centers, masks, and projection

- Updated `rasterio_dataset_to_structured_data` to compute coordinates using pixel centers and mask nodata values as `NaN`.
- Added handling for geographic CRS by projecting coordinates to metric system.
- Introduced helper functions: `_get_raster_center_coords` and `_geographic_coords_to_metric_coords` for coordinate transformation.
- Added memory raster creation (`_memory_raster`) and tests to validate new functionalities (`test_rasterio_dataset_to_structured_data_uses_pixel_centers_and_masks_nodata`, `test_rasterio_dataset_to_structured_data_projects_geographic_coords_to_metric`).

[TEST] Add test for Soricom DEM GeoTIFF with raw and pipeline visualization

- Added `test_read_soricom_geotiff` to validate GeoTIFF reading and processing for Soricom DEM.
- Included raw rasterio and subsurface pipeline comparison plots for verification.

[ENH] Refactor raster processing and add test for unsigned integer nodata handling

- Introduced `_read_raster_band_as_float` to handle raster band data conversion to float with masking of unsigned integer max values as `NaN` when nodata is undefined.
- Updated `rasterio_dataset_to_structured_data` to use the new helper function.
- Added `test_rasterio_dataset_to_structured_data_masks_unsigned_integer_max_without_nodata` to validate functionality.

[ENH] Add band selection for raster processing and enhance tests

- Updated `read_structured_topography` and `rasterio_dataset_to_structured_data` to support optional band selection.
- Introduced `_select_raster_band` to auto-detect the richest band when not explicitly provided.
- Enhanced raster band reading logic in `_read_raster_band_as_float` to account for multi-band datasets with nodata handling.
- Added new tests (`test_rasterio_dataset_to_structured_data_can_read_requested_band`, `test_rasterio_dataset_to_structured_data_auto_selects_richest_band`) to verify functionality.
- Updated `_memory_raster` to handle multi-band raster creation for testing.

[TEST] Update GeoTIFF test to include cropping to extent in `read_structured_topography`

- Modified `test_read_soricom_geotiff` to pass `crop_to_extent` argument for enhanced testing of raster processing functionality.

[ENH] Refactor raster window extraction and add tests for crop-to-extent logic

- Improved `_get_raster_window` to use `rasterio.windows.from_bounds` for enhanced raster window computation.
- Added validation for non-overlapping extents in `_get_raster_window`.
- Introduced tests (`test_rasterio_dataset_to_structured_data_crops_to_extent`, `test_rasterio_dataset_to_structured_data_clips_crop_to_raster_bounds`) to verify `crop_to_extent` functionality.
- Updated `_raw_rasterio_plot` to include crop visualization with bounding box.

[TEST] Update GeoTIFF test to modify `crop_to_extent` values in `_get_raster_window` and `test_geotiff_I` for raster window validation