### PR TITLE
[FIX] Handle NaN angles, non-numeric column warnings, and add `coerce_numeric` support for borehole readers

### DIFF
--- a/subsurface/core/geological_formats/boreholes/_map_attrs_to_survey.py
+++ b/subsurface/core/geological_formats/boreholes/_map_attrs_to_survey.py
@@ -1,4 +1,6 @@
-﻿import numpy as np
+﻿import warnings
+
+import numpy as np
 import pandas as pd
 import xarray as xr
 from typing import Tuple, Optional, Union, List, Any
@@ -282,6 +284,7 @@ def _map_attrs_to_measured_depths(attrs: pd.DataFrame, survey_trajectory: LineSe
     new_attrs: pd.DataFrame = _prepare_new_attributes(attrs, survey_trajectory)
 
     # Process each well
+    _warned_skipped_columns = set()
     for well_name in well_id_mapper:
         # Skip wells not in the attributes DataFrame
         if well_name not in attrs.index:
@@ -310,6 +313,20 @@ def _map_attrs_to_measured_depths(attrs: pd.DataFrame, survey_trajectory: LineSe
 
             # Skip columns that can't be interpolated and aren't categorical
             if is_categorical and col not in ['lith_ids', 'component lith']:
+                if col not in _warned_skipped_columns:
+                    _warned_skipped_columns.add(col)
+                    non_null_sample = attr_values.dropna()
+                    sample_str = (
+                        f", sample values: {non_null_sample.head(3).tolist()}"
+                        if not non_null_sample.empty
+                        else ""
+                    )
+                    warnings.warn(
+                        f"Column '{col}' has non-numeric dtype ({attr_values.dtype}) "
+                        f"and will be skipped during interpolation for all wells.{sample_str}. "
+                        f"To include numeric-like string columns, set coerce_numeric=True "
+                        f"in the reader config or pre-process the data."
+                    )
                 continue
 
             # Interpolate and assign values

--- a/subsurface/core/geological_formats/boreholes/_map_attrs_to_survey.py
+++ b/subsurface/core/geological_formats/boreholes/_map_attrs_to_survey.py
@@ -324,8 +324,8 @@ def _map_attrs_to_measured_depths(attrs: pd.DataFrame, survey_trajectory: LineSe
                     warnings.warn(
                         f"Column '{col}' has non-numeric dtype ({attr_values.dtype}) "
                         f"and will be skipped during interpolation for all wells.{sample_str}. "
-                        f"To include numeric-like string columns, set coerce_numeric=True "
-                        f"in the reader config or pre-process the data."
+                        f"To include numeric-like string columns, add them to "
+                        f"coerce_numeric in the reader config or pre-process the data."
                     )
                 continue
 

--- a/subsurface/core/geological_formats/boreholes/survey.py
+++ b/subsurface/core/geological_formats/boreholes/survey.py
@@ -71,18 +71,21 @@ class Survey:
 
 def _correct_angles(df: pd.DataFrame) -> pd.DataFrame:
     def correct_inclination(inc: float) -> float:
+        if pd.isna(inc):
+            return inc
         if inc < 0:
-            inc = inc % 360  # Normalize to 0-360 range first if negative
+            inc = inc % 360
         if 0 <= inc <= 180:
-            # add or subtract a very small number to make sure that 0 or 180 are never possible
             return inc + 1e-10 if inc == 0 else inc - 1e-10
         elif 180 < inc < 360:
-            return 360 - inc  # Reflect angles greater than 180 back into the 0-180 range
+            return 360 - inc
         else:
             raise ValueError(f'Inclination value {inc} is out of the expected range of 0 to 360 degrees')
 
     def correct_azimuth(azi: float) -> float:
-        return azi % 360  # Normalize azimuth to 0-360 range
+        if pd.isna(azi):
+            return azi
+        return azi % 360
 
     df['inc'] = df['inc'].apply(correct_inclination)
     df['azi'] = df['azi'].apply(correct_azimuth)

--- a/subsurface/core/reader_helpers/readers_data.py
+++ b/subsurface/core/reader_helpers/readers_data.py
@@ -35,6 +35,7 @@ class GenericReaderFilesHelper(BaseModel):
     encoding: str = "utf-8"
     index_col: Optional[Union[int, str, bool]] = False
     header: Union[None, int, List[int]] = 0
+    coerce_numeric: bool = False
 
     # Computed fields
     file_or_buffer_type: str = Field(init=False)

--- a/subsurface/core/reader_helpers/readers_data.py
+++ b/subsurface/core/reader_helpers/readers_data.py
@@ -125,7 +125,7 @@ class GenericReaderFilesHelper(BaseModel):
             delimiter = self.additional_reader_kwargs.get("delimiter", None)
         else:
             delimiter = None
-        if self.separator is not None and delimiter is None:
+        if delimiter is None:
             attr_dict["sep"] = self.separator
         
         return {**attr_dict, **self.additional_reader_kwargs}

--- a/subsurface/core/reader_helpers/readers_data.py
+++ b/subsurface/core/reader_helpers/readers_data.py
@@ -35,7 +35,7 @@ class GenericReaderFilesHelper(BaseModel):
     encoding: str = "utf-8"
     index_col: Optional[Union[int, str, bool]] = False
     header: Union[None, int, List[int]] = 0
-    coerce_numeric: bool = False
+    coerce_numeric: Optional[List[str]] = None
 
     # Computed fields
     file_or_buffer_type: str = Field(init=False)

--- a/subsurface/core/utils/utils_core.py
+++ b/subsurface/core/utils/utils_core.py
@@ -10,7 +10,7 @@ def get_extension(path):
         p = Path(path)
         return p.suffix
     except TypeError:
-        return False
+        return ""
 
 
 def replace_outliers(base_data: Union[StructuredData, UnstructuredData], dim=0, perc=0.99, replace_for=None):

--- a/subsurface/modules/reader/mesh/csv_mesh_reader.py
+++ b/subsurface/modules/reader/mesh/csv_mesh_reader.py
@@ -6,14 +6,14 @@ import pandas as pd
 
 def mesh_csv_to_vertex(path_to_file: str, columns_map: Union[None, Callable, dict, pd.Series] = None,
                        **reader_kwargs) -> np.ndarray:
-    data = pd.read_csv(path_to_file, **reader_kwargs)
+    data = pd.read_csv(path_to_file, engine='python', **reader_kwargs)
     if columns_map is not None: map_columns_names(columns_map, data)
     return get_vertices_from_df(data)
 
 
 def mesh_csv_to_cells(path_to_file: str, columns_map: Union[None, Callable, dict, pd.Series] = None,
-                      **reader_kwargs) -> np.ndarray:
-    data = pd.read_csv(path_to_file, **reader_kwargs)
+                       **reader_kwargs) -> np.ndarray:
+    data = pd.read_csv(path_to_file, engine='python', **reader_kwargs)
     if columns_map is not None: map_columns_names(columns_map, data)
     return get_cells_from_df(data)
 
@@ -21,7 +21,7 @@ def mesh_csv_to_cells(path_to_file: str, columns_map: Union[None, Callable, dict
 def mesh_csv_to_attributes(path_to_file: str,
                            columns_map: Union[None, Callable, dict, pd.Series] = None,
                            **reader_kwargs) -> pd.DataFrame:
-    data = pd.read_csv(path_to_file, **reader_kwargs)
+    data = pd.read_csv(path_to_file, engine='python', **reader_kwargs)
     if columns_map is not None:
         map_columns_names(columns_map, data)
     return data

--- a/subsurface/modules/reader/wells/_read_to_df.py
+++ b/subsurface/modules/reader/wells/_read_to_df.py
@@ -13,22 +13,16 @@ def check_format_and_read_to_df(reader_helper: GenericReaderFilesHelper) -> pd.D
             d = pd.read_json(reader_helper.file_or_buffer, orient='split')
         case str() | pathlib.Path(), _:
             reader: Callable = _get_reader(reader_helper.format)
-            base_kwargs = {"engine": "python"}
-            if reader_helper.separator is not None:
-                base_kwargs["sep"] = reader_helper.separator
             d = reader(
                 filepath_or_buffer=reader_helper.file_or_buffer,
-                **base_kwargs,
+                engine='python',
                 **reader_helper.pandas_reader_kwargs,
             )
         case (bytes() | io.BytesIO() | io.StringIO() | io.TextIOWrapper()), _:
             reader = _get_reader(reader_helper.format)
-            base_kwargs = {"engine": "python"}
-            if reader_helper.separator is not None:
-                base_kwargs["sep"] = reader_helper.separator
             d = reader(
                 filepath_or_buffer=reader_helper.file_or_buffer,
-                **base_kwargs,
+                engine='python',
                 **reader_helper.pandas_reader_kwargs,
             )
         case dict(), _:

--- a/subsurface/modules/reader/wells/_read_to_df.py
+++ b/subsurface/modules/reader/wells/_read_to_df.py
@@ -13,19 +13,23 @@ def check_format_and_read_to_df(reader_helper: GenericReaderFilesHelper) -> pd.D
             d = pd.read_json(reader_helper.file_or_buffer, orient='split')
         case str() | pathlib.Path(), _:
             reader: Callable = _get_reader(reader_helper.format)
+            base_kwargs = {"engine": "python"}
+            if reader_helper.separator is not None:
+                base_kwargs["sep"] = reader_helper.separator
             d = reader(
                 filepath_or_buffer=reader_helper.file_or_buffer,
-                sep=reader_helper.separator,
-                engine='python',
-                **reader_helper.pandas_reader_kwargs
+                **base_kwargs,
+                **reader_helper.pandas_reader_kwargs,
             )
         case (bytes() | io.BytesIO() | io.StringIO() | io.TextIOWrapper()), _:
             reader = _get_reader(reader_helper.format)
+            base_kwargs = {"engine": "python"}
+            if reader_helper.separator is not None:
+                base_kwargs["sep"] = reader_helper.separator
             d = reader(
                 filepath_or_buffer=reader_helper.file_or_buffer,
-                sep=reader_helper.separator,
-                engine='python',
-                **reader_helper.pandas_reader_kwargs
+                **base_kwargs,
+                **reader_helper.pandas_reader_kwargs,
             )
         case dict(), _:
             reader = _get_reader('dict')

--- a/subsurface/modules/reader/wells/read_borehole_interface.py
+++ b/subsurface/modules/reader/wells/read_borehole_interface.py
@@ -14,6 +14,7 @@ def read_collar(reader_helper: GenericReaderFilesHelper) -> pd.DataFrame:
     # Check file_or_buffer type
     data_df: pd.DataFrame = check_format_and_read_to_df(reader_helper)
     _map_rows_and_cols_inplace(data_df, reader_helper)
+    _coerce_numeric_columns(data_df, reader_helper)
 
     # Remove duplicates
     data_df = data_df[~data_df.index.duplicated(keep='first')]
@@ -46,6 +47,7 @@ def read_attributes(reader_helper: GenericReaderFilesHelper, is_lith: bool = Fal
     d = check_format_and_read_to_df(reader_helper)
 
     _map_rows_and_cols_inplace(d, reader_helper)
+    _coerce_numeric_columns(d, reader_helper)
     if validate_attr is False:
         return d
     
@@ -54,6 +56,13 @@ def read_attributes(reader_helper: GenericReaderFilesHelper, is_lith: bool = Fal
     else:
         _validate_attr_data(d)
     return d
+
+
+def _coerce_numeric_columns(d: pd.DataFrame, reader_helper: GenericReaderFilesHelper) -> None:
+    if reader_helper.coerce_numeric:
+        for col in d.columns:
+            if col not in ('dip',):
+                d[col] = pd.to_numeric(d[col], errors='coerce')
 
 
 def _map_rows_and_cols_inplace(d: pd.DataFrame, reader_helper: GenericReaderFilesHelper):
@@ -69,8 +78,12 @@ def _validate_survey_data(d):
         raise AttributeError(
             'md, inc, and azi columns must be present in the file. Use columns_map to assign column names to these fields.')
 
+    # Drop rows with NaN in essential survey columns
+    d.dropna(subset=['md'], inplace=True)
+
     # Check if 'dip' column exists and convert it to 'inc'
     if 'dip' in d.columns:
+        d.dropna(subset=['dip'], inplace=True)
         # Convert dip to inclination (90 - dip)
         d['inc'] = 90 - d['dip']
         # Optionally, drop the 'dip' column if it's no longer needed

--- a/subsurface/modules/reader/wells/read_borehole_interface.py
+++ b/subsurface/modules/reader/wells/read_borehole_interface.py
@@ -59,9 +59,9 @@ def read_attributes(reader_helper: GenericReaderFilesHelper, is_lith: bool = Fal
 
 
 def _coerce_numeric_columns(d: pd.DataFrame, reader_helper: GenericReaderFilesHelper) -> None:
-    if reader_helper.coerce_numeric:
-        for col in d.columns:
-            if col not in ('dip',):
+    if reader_helper.coerce_numeric is not None:
+        for col in reader_helper.coerce_numeric:
+            if col in d.columns:
                 d[col] = pd.to_numeric(d[col], errors='coerce')
 
 

--- a/tests/test_io/test_lines/test_atalaya.py
+++ b/tests/test_io/test_lines/test_atalaya.py
@@ -345,3 +345,101 @@ def test_read_atalaya_assays_via_dict():
     assert len(cu_values) > 0
     au_values = mr01_attrs["Au ppm"].dropna()
     assert len(au_values) > 0
+
+
+def _make_raw_assay_dict():
+    raw = pd.read_csv(
+        os.path.join(_DATA_PATH, "Assay_Mojarra.csv"),
+        sep=";",
+        index_col=0,
+    )
+    return _df_to_dict(raw)
+
+
+class TestDiagnosticRawDictGaps:
+    """
+    Diagnostic tests that expose gaps in read_wells when fed raw (uncleaned)
+    data via JSON/dict input.
+
+    These tests pass *as-is* (they assert current behavior) but they document
+    what's broken and what needs fixing in read_wells / GenericReaderFilesHelper.
+    """
+
+    @pytest.mark.xfail(
+        reason="BUG: _correct_angles crashes on NaN inc from blank survey rows"
+    )
+    def test_raw_survey_crashes_in_correct_angles(self):
+        raw_survey = pd.read_csv(
+            os.path.join(_DATA_PATH, "Survey_Mojarra.csv"),
+            sep=";",
+            index_col=0,
+        )
+        survey_dict = _df_to_dict(raw_survey)
+
+        collar_reader = GenericReaderFilesHelper(
+            file_or_buffer=_df_to_dict(pd.read_csv(
+                os.path.join(_DATA_PATH, "Collar_Mojarra.csv"),
+                sep=";", encoding="latin-1", index_col=0,
+            )),
+            columns_map={"BHID": "id", "XCOLLAR": "x", "YCOLLAR": "y", "ZCOLLAR": "z"},
+        )
+        survey_reader = GenericReaderFilesHelper(
+            file_or_buffer=survey_dict,
+            columns_map={"AT": "md", "BRG": "azi", "DIP": "dip"},
+        )
+        attr_reader = GenericReaderFilesHelper(
+            file_or_buffer=_make_raw_assay_dict(),
+            columns_map={"HoleID": "id", "From": "top", "To": "base"},
+        )
+
+        read_wells(
+            collars_reader=collar_reader,
+            surveys_reader=survey_reader,
+            attrs_reader=attr_reader,
+            is_lith_attr=False,
+            add_attrs_as_nodes=True,
+        )
+
+    def test_raw_assay_columns_exist_but_all_none(self):
+        raw_survey = pd.read_csv(
+            os.path.join(_DATA_PATH, "Survey_Mojarra.csv"),
+            sep=";",
+            index_col=0,
+        )
+        raw_survey.index = raw_survey.index.where(raw_survey.index.notna(), None)
+        raw_survey = raw_survey[raw_survey.index.notna() & raw_survey.index.notnull()]
+        raw_survey = raw_survey[raw_survey.index.duplicated(keep=False)]
+        survey_dict = _df_to_dict(raw_survey)
+
+        collar_reader = GenericReaderFilesHelper(
+            file_or_buffer=_df_to_dict(pd.read_csv(
+                os.path.join(_DATA_PATH, "Collar_Mojarra.csv"),
+                sep=";", encoding="latin-1", index_col=0,
+            )),
+            columns_map={"BHID": "id", "XCOLLAR": "x", "YCOLLAR": "y", "ZCOLLAR": "z"},
+        )
+        survey_reader = GenericReaderFilesHelper(
+            file_or_buffer=survey_dict,
+            columns_map={"AT": "md", "BRG": "azi", "DIP": "dip"},
+        )
+        attr_reader = GenericReaderFilesHelper(
+            file_or_buffer=_make_raw_assay_dict(),
+            columns_map={"HoleID": "id", "From": "top", "To": "base"},
+        )
+
+        borehole_set = read_wells(
+            collars_reader=collar_reader,
+            surveys_reader=survey_reader,
+            attrs_reader=attr_reader,
+            is_lith_attr=False,
+            add_attrs_as_nodes=True,
+        )
+
+        points_attrs = borehole_set.combined_trajectory.data.points_attributes
+
+        # BUG: columns exist but all values are None because
+        #      'n.a.' / '<0.05' force object dtype -> skipped by interpolation
+        assert "Cu %" in points_attrs.columns
+        assert points_attrs["Cu %"].isna().all()
+        assert "Au ppm" in points_attrs.columns
+        assert points_attrs["Au ppm"].isna().all()

--- a/tests/test_io/test_lines/test_atalaya.py
+++ b/tests/test_io/test_lines/test_atalaya.py
@@ -1,0 +1,250 @@
+import os
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from subsurface.core.geological_formats.boreholes.boreholes import BoreholeSet, MergeOptions
+from subsurface.core.geological_formats.boreholes.collars import Collars
+from subsurface.core.geological_formats.boreholes.survey import Survey
+from tests.conftest import RequirementsLevel
+
+_TERRA_PATH = os.getenv("TERRA_PATH_DEVOPS")
+_DATA_PATH = os.path.join(_TERRA_PATH, "boreholes", "Atalaya")
+
+pytestmark = pytest.mark.skipif(
+    condition=(RequirementsLevel.READ_WELL) not in RequirementsLevel.REQUIREMENT_LEVEL_TO_TEST(),
+    reason="Need to set the READ_WELL",
+)
+
+
+def _read_collar_df():
+    df = pd.read_csv(
+        os.path.join(_DATA_PATH, "Collar_Mojarra.csv"),
+        sep=";",
+        encoding="latin-1",
+        index_col=0,
+    )
+    df.rename(
+        columns={
+            "BHID": "id",
+            "XCOLLAR": "x",
+            "YCOLLAR": "y",
+            "ZCOLLAR": "z",
+        },
+        inplace=True,
+    )
+    return df
+
+
+def _read_survey_df():
+    df = pd.read_csv(
+        os.path.join(_DATA_PATH, "Survey_Mojarra.csv"),
+        sep=";",
+        index_col=0,
+    )
+    df.rename(
+        columns={
+            "AT": "md",
+            "BRG": "azi",
+            "DIP": "dip",
+        },
+        inplace=True,
+    )
+    df["inc"] = 90 - df["dip"]
+    df.drop(columns=["dip"], inplace=True)
+    df = df[df.index.duplicated(keep=False)]
+    df.dropna(subset=["inc", "azi"], inplace=True)
+    return df
+
+
+def _read_lith_df():
+    df = pd.read_csv(
+        os.path.join(_DATA_PATH, "Litho_Mojarra.csv"),
+        sep=";",
+        encoding="latin-1",
+        index_col=0,
+    )
+    df.rename(
+        columns={
+            "BHID": "id",
+            "FROM": "top",
+            "TO": "base",
+            "LITHO": "component lith",
+        },
+        inplace=True,
+    )
+    return df
+
+
+def _read_assay_df():
+    df = pd.read_csv(
+        os.path.join(_DATA_PATH, "Assay_Mojarra.csv"),
+        sep=";",
+        index_col=0,
+    )
+    df.rename(
+        columns={
+            "HoleID": "id",
+            "From": "top",
+            "To": "base",
+        },
+        inplace=True,
+    )
+    return df
+
+
+def test_read_atalaya_collar():
+    df = _read_collar_df()
+    assert not df.empty
+    assert len(df) == 29
+    assert "x" in df.columns
+    assert "y" in df.columns
+    assert "z" in df.columns
+
+    assert "EST01" in df.index
+    assert "MR01" in df.index
+    assert "MR24" in df.index
+
+    collars = Collars.from_df(df)
+    assert collars.collar_loc.n_points == 29
+    assert collars.collar_loc.n_points == len(collars.ids)
+
+
+def test_read_atalaya_survey():
+    df = _read_survey_df()
+    assert not df.empty
+    assert "md" in df.columns
+    assert "inc" in df.columns
+    assert "azi" in df.columns
+
+    survey = Survey.from_df(df)
+    assert survey.survey_trajectory.data.n_points > 0
+
+
+def test_read_atalaya_full_lithology():
+    collar_df = _read_collar_df()
+    survey_df = _read_survey_df()
+    lith_df = _read_lith_df()
+
+    survey = Survey.from_df(
+        survey_df=survey_df,
+        attr_df=lith_df,
+        number_nodes=10,
+        duplicate_attr_depths=True,
+    )
+    survey.update_survey_with_lith(lith_df)
+
+    collars = Collars.from_df(collar_df)
+    borehole_set = BoreholeSet(
+        collars=collars,
+        survey=survey,
+        merge_option=MergeOptions.INTERSECT,
+    )
+
+    assert "EST01" in borehole_set.collars.ids
+    assert "MR24" in borehole_set.collars.ids
+
+    collar_count = len(borehole_set.collars.ids)
+    assert collar_count >= 29
+
+    assert hasattr(borehole_set.survey, "survey_trajectory")
+
+    points_attrs = borehole_set.combined_trajectory.data.points_attributes
+    assert "component lith" in points_attrs.columns
+    assert "lith_ids" in points_attrs.columns
+
+    est01_id = borehole_set.survey.get_well_num_id("EST01")
+    est01_attrs = points_attrs[points_attrs["well_id"] == est01_id]
+    assert not est01_attrs.empty
+
+    lith_codes = est01_attrs["component lith"].dropna().unique()
+    assert len(lith_codes) > 0
+    assert any("VR" in str(c) or c == "VR" for c in lith_codes)
+    assert any("VT" in str(c) or c == "VT" for c in lith_codes)
+
+
+def test_read_atalaya_assays():
+    collar_df = _read_collar_df()
+    survey_df = _read_survey_df()
+    attrs = _read_assay_df()
+
+    assert not attrs.empty
+    raw_assay_cols = [c for c in attrs.columns if c not in ("top", "base")]
+    assert len(raw_assay_cols) > 0
+    assert "Cu %" in raw_assay_cols
+    assert "Au ppm" in raw_assay_cols
+
+    for col in attrs.columns:
+        if col not in ("top", "base"):
+            attrs[col] = pd.to_numeric(attrs[col], errors="coerce")
+
+    collars = Collars.from_df(collar_df)
+    survey = Survey.from_df(
+        survey_df=survey_df,
+        attr_df=attrs,
+        number_nodes=10,
+        duplicate_attr_depths=True,
+    )
+    survey.update_survey_with_attr(attrs)
+
+    borehole_set = BoreholeSet(
+        collars=collars,
+        survey=survey,
+        merge_option=MergeOptions.INTERSECT,
+    )
+
+    points_attrs = borehole_set.combined_trajectory.data.points_attributes
+    assert "Cu %" in points_attrs.columns
+    assert "Au ppm" in points_attrs.columns
+
+    mr01_id = borehole_set.survey.get_well_num_id("MR01")
+    mr01_attrs = points_attrs[points_attrs["well_id"] == mr01_id]
+    assert not mr01_attrs.empty
+
+    cu_values = mr01_attrs["Cu %"].dropna()
+    assert len(cu_values) > 0
+
+    mr01_vertices = borehole_set.combined_trajectory.data.vertex[
+        points_attrs["well_id"] == mr01_id
+    ]
+    assert mr01_vertices.shape[0] > 0
+
+    expected_x = 692622.949
+    expected_y = 4158049.67
+    assert np.isclose(mr01_vertices[0, 0], expected_x, rtol=1e-5)
+    assert np.isclose(mr01_vertices[0, 1], expected_y, rtol=1e-5)
+
+
+def test_read_atalaya_lithology_with_explicit_mapping():
+    collar_df = _read_collar_df()
+    survey_df = _read_survey_df()
+    lith_df = _read_lith_df()
+
+    survey = Survey.from_df(
+        survey_df=survey_df,
+        attr_df=lith_df,
+        number_nodes=0,
+        duplicate_attr_depths=True,
+    )
+    survey.update_survey_with_lith(lith_df)
+
+    collars = Collars.from_df(collar_df)
+    borehole_set = BoreholeSet(
+        collars=collars,
+        survey=survey,
+        merge_option=MergeOptions.INTERSECT,
+    )
+
+    assert len(borehole_set.collars.ids) >= 29
+
+    points_attrs = borehole_set.combined_trajectory.data.points_attributes
+    assert "component lith" in points_attrs.columns
+    assert "lith_ids" in points_attrs.columns
+
+    vertices = borehole_set.combined_trajectory.data.vertex
+    n = vertices.shape[0]
+    assert n > 0
+
+    unique_lith_ids = points_attrs["lith_ids"].unique()
+    assert len(unique_lith_ids) > 1

--- a/tests/test_io/test_lines/test_atalaya.py
+++ b/tests/test_io/test_lines/test_atalaya.py
@@ -358,17 +358,14 @@ def _make_raw_assay_dict():
 
 class TestDiagnosticRawDictGaps:
     """
-    Diagnostic tests that expose gaps in read_wells when fed raw (uncleaned)
-    data via JSON/dict input.
+    Diagnostic tests showing the behavior of read_wells with raw (uncleaned)
+    dict/JSON input, and how the coerce_numeric fix resolves the issues.
 
-    These tests pass *as-is* (they assert current behavior) but they document
-    what's broken and what needs fixing in read_wells / GenericReaderFilesHelper.
+    FIXED: raw survey no longer crashes (NaN rows are dropped in _validate_survey_data).
+           raw assay with coerce_numeric=True now interpolates correctly.
     """
 
-    @pytest.mark.xfail(
-        reason="BUG: _correct_angles crashes on NaN inc from blank survey rows"
-    )
-    def test_raw_survey_crashes_in_correct_angles(self):
+    def test_raw_survey_no_longer_crashes(self):
         raw_survey = pd.read_csv(
             os.path.join(_DATA_PATH, "Survey_Mojarra.csv"),
             sep=";",
@@ -392,13 +389,15 @@ class TestDiagnosticRawDictGaps:
             columns_map={"HoleID": "id", "From": "top", "To": "base"},
         )
 
-        read_wells(
+        # Previously crashed in _correct_angles, now succeeds.
+        borehole_set = read_wells(
             collars_reader=collar_reader,
             surveys_reader=survey_reader,
             attrs_reader=attr_reader,
             is_lith_attr=False,
             add_attrs_as_nodes=True,
         )
+        assert borehole_set.combined_trajectory.data.n_points > 0
 
     def test_raw_assay_columns_exist_but_all_none(self):
         raw_survey = pd.read_csv(
@@ -427,6 +426,49 @@ class TestDiagnosticRawDictGaps:
             columns_map={"HoleID": "id", "From": "top", "To": "base"},
         )
 
+        with pytest.warns(UserWarning, match="non-numeric dtype"):
+            borehole_set = read_wells(
+                collars_reader=collar_reader,
+                surveys_reader=survey_reader,
+                attrs_reader=attr_reader,
+                is_lith_attr=False,
+                add_attrs_as_nodes=True,
+            )
+
+        points_attrs = borehole_set.combined_trajectory.data.points_attributes
+        assert "Cu %" in points_attrs.columns
+        assert points_attrs["Cu %"].isna().all()
+        assert "Au ppm" in points_attrs.columns
+        assert points_attrs["Au ppm"].isna().all()
+
+    def test_raw_assay_with_coerce_numeric_works(self):
+        raw_survey = pd.read_csv(
+            os.path.join(_DATA_PATH, "Survey_Mojarra.csv"),
+            sep=";",
+            index_col=0,
+        )
+        raw_survey.index = raw_survey.index.where(raw_survey.index.notna(), None)
+        raw_survey = raw_survey[raw_survey.index.notna() & raw_survey.index.notnull()]
+        raw_survey = raw_survey[raw_survey.index.duplicated(keep=False)]
+        survey_dict = _df_to_dict(raw_survey)
+
+        collar_reader = GenericReaderFilesHelper(
+            file_or_buffer=_df_to_dict(pd.read_csv(
+                os.path.join(_DATA_PATH, "Collar_Mojarra.csv"),
+                sep=";", encoding="latin-1", index_col=0,
+            )),
+            columns_map={"BHID": "id", "XCOLLAR": "x", "YCOLLAR": "y", "ZCOLLAR": "z"},
+        )
+        survey_reader = GenericReaderFilesHelper(
+            file_or_buffer=survey_dict,
+            columns_map={"AT": "md", "BRG": "azi", "DIP": "dip"},
+        )
+        attr_reader = GenericReaderFilesHelper(
+            file_or_buffer=_make_raw_assay_dict(),
+            columns_map={"HoleID": "id", "From": "top", "To": "base"},
+            coerce_numeric=True,
+        )
+
         borehole_set = read_wells(
             collars_reader=collar_reader,
             surveys_reader=survey_reader,
@@ -436,10 +478,14 @@ class TestDiagnosticRawDictGaps:
         )
 
         points_attrs = borehole_set.combined_trajectory.data.points_attributes
-
-        # BUG: columns exist but all values are None because
-        #      'n.a.' / '<0.05' force object dtype -> skipped by interpolation
         assert "Cu %" in points_attrs.columns
-        assert points_attrs["Cu %"].isna().all()
         assert "Au ppm" in points_attrs.columns
-        assert points_attrs["Au ppm"].isna().all()
+
+        mr01_id = borehole_set.survey.get_well_num_id("MR01")
+        mr01_attrs = points_attrs[points_attrs["well_id"] == mr01_id]
+        assert not mr01_attrs.empty
+
+        cu_values = mr01_attrs["Cu %"].dropna()
+        assert len(cu_values) > 0
+        au_values = mr01_attrs["Au ppm"].dropna()
+        assert len(au_values) > 0

--- a/tests/test_io/test_lines/test_atalaya.py
+++ b/tests/test_io/test_lines/test_atalaya.py
@@ -466,7 +466,12 @@ class TestDiagnosticRawDictGaps:
         attr_reader = GenericReaderFilesHelper(
             file_or_buffer=_make_raw_assay_dict(),
             columns_map={"HoleID": "id", "From": "top", "To": "base"},
-            coerce_numeric=True,
+            coerce_numeric=[
+                "Cu %", "S %", "Pb %", "Zn %", "As %", "Sb %", "Bi %",
+                "Hg ppm", "Fe %", "Th  ppm", "Ag ppm", "Cd %",
+                "Co %", "Ni %", "Mn %", "Al %", "Ca %", "Mg %",
+                "Sn ppm", "Mo %", "P %", "Tl %", "Au ppm",
+            ],
         )
 
         borehole_set = read_wells(

--- a/tests/test_io/test_lines/test_atalaya.py
+++ b/tests/test_io/test_lines/test_atalaya.py
@@ -7,6 +7,8 @@ import pytest
 from subsurface.core.geological_formats.boreholes.boreholes import BoreholeSet, MergeOptions
 from subsurface.core.geological_formats.boreholes.collars import Collars
 from subsurface.core.geological_formats.boreholes.survey import Survey
+from subsurface.core.reader_helpers.readers_data import GenericReaderFilesHelper
+from subsurface.api.reader.read_wells import read_wells
 from tests.conftest import RequirementsLevel
 
 _TERRA_PATH = os.getenv("TERRA_PATH_DEVOPS")
@@ -91,6 +93,26 @@ def _read_assay_df():
         },
         inplace=True,
     )
+    return df
+
+
+def _df_to_dict(df: pd.DataFrame) -> dict:
+    return {
+        "data": df.values.tolist(),
+        "columns": list(df.columns),
+        "index": df.index.tolist(),
+    }
+
+
+def _clean_assay_numerics(df: pd.DataFrame) -> pd.DataFrame:
+    df = df.copy()
+    for col in df.columns:
+        if col in ("HoleID", "From", "To"):
+            continue
+        df[col] = pd.to_numeric(
+            df[col].replace(r"^(n\.a\.|<.*)$", None, regex=True),
+            errors="coerce",
+        )
     return df
 
 
@@ -248,3 +270,78 @@ def test_read_atalaya_lithology_with_explicit_mapping():
 
     unique_lith_ids = points_attrs["lith_ids"].unique()
     assert len(unique_lith_ids) > 1
+
+
+def test_read_atalaya_assays_via_dict():
+    collar_df = pd.read_csv(
+        os.path.join(_DATA_PATH, "Collar_Mojarra.csv"),
+        sep=";",
+        encoding="latin-1",
+        index_col=0,
+    )
+    survey_df = pd.read_csv(
+        os.path.join(_DATA_PATH, "Survey_Mojarra.csv"),
+        sep=";",
+        index_col=0,
+    )
+    survey_df.index = survey_df.index.where(survey_df.index.notna(), None)
+    survey_df = survey_df[survey_df.index.notna() & survey_df.index.notnull()]
+    survey_df = survey_df[survey_df.index.duplicated(keep=False)]
+
+    raw_assay_df = pd.read_csv(
+        os.path.join(_DATA_PATH, "Assay_Mojarra.csv"),
+        sep=";",
+        index_col=0,
+    )
+    assay_df = _clean_assay_numerics(raw_assay_df)
+
+    collar_dict = _df_to_dict(collar_df)
+    survey_dict = _df_to_dict(survey_df)
+    assay_dict = _df_to_dict(assay_df)
+
+    collar_reader = GenericReaderFilesHelper(
+        file_or_buffer=collar_dict,
+        columns_map={
+            "BHID": "id",
+            "XCOLLAR": "x",
+            "YCOLLAR": "y",
+            "ZCOLLAR": "z",
+        },
+    )
+    survey_reader = GenericReaderFilesHelper(
+        file_or_buffer=survey_dict,
+        columns_map={
+            "AT": "md",
+            "BRG": "azi",
+            "DIP": "dip",
+        },
+    )
+    assay_reader = GenericReaderFilesHelper(
+        file_or_buffer=assay_dict,
+        columns_map={
+            "HoleID": "id",
+            "From": "top",
+            "To": "base",
+        },
+    )
+
+    borehole_set = read_wells(
+        collars_reader=collar_reader,
+        surveys_reader=survey_reader,
+        attrs_reader=assay_reader,
+        is_lith_attr=False,
+        add_attrs_as_nodes=True,
+    )
+
+    assert "Cu %" in borehole_set.combined_trajectory.data.points_attributes.columns
+    assert "Au ppm" in borehole_set.combined_trajectory.data.points_attributes.columns
+
+    mr01_id = borehole_set.survey.get_well_num_id("MR01")
+    points_attrs = borehole_set.combined_trajectory.data.points_attributes
+    mr01_attrs = points_attrs[points_attrs["well_id"] == mr01_id]
+    assert not mr01_attrs.empty
+
+    cu_values = mr01_attrs["Cu %"].dropna()
+    assert len(cu_values) > 0
+    au_values = mr01_attrs["Au ppm"].dropna()
+    assert len(au_values) > 0

--- a/tests/test_io/test_lines/test_atalaya.py
+++ b/tests/test_io/test_lines/test_atalaya.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 import numpy as np
@@ -18,6 +19,8 @@ pytestmark = pytest.mark.skipif(
     condition=(RequirementsLevel.READ_WELL) not in RequirementsLevel.REQUIREMENT_LEVEL_TO_TEST(),
     reason="Need to set the READ_WELL",
 )
+
+WRITE_JSON = True
 
 
 def _read_collar_df():
@@ -494,3 +497,79 @@ class TestDiagnosticRawDictGaps:
         assert len(cu_values) > 0
         au_values = mr01_attrs["Au ppm"].dropna()
         assert len(au_values) > 0
+
+
+def test_atalaya_serialized_json_roundtrip():
+    collar_readers = GenericReaderFilesHelper(
+        file_or_buffer=os.path.join(_DATA_PATH, "Collar_Mojarra.csv"),
+        encoding="latin-1",
+        columns_map={
+            "BHID": "id", "XCOLLAR": "x", "YCOLLAR": "y", "ZCOLLAR": "z",
+        },
+        additional_reader_kwargs={"sep": ";"},
+    )
+    survey_readers = GenericReaderFilesHelper(
+        file_or_buffer=os.path.join(_DATA_PATH, "Survey_Mojarra.csv"),
+        columns_map={"AT": "md", "BRG": "azi", "DIP": "dip"},
+        additional_reader_kwargs={"sep": ";"},
+    )
+    assay_readers = GenericReaderFilesHelper(
+        file_or_buffer=os.path.join(_DATA_PATH, "Assay_Mojarra.csv"),
+        columns_map={"HoleID": "id", "From": "top", "To": "base"},
+        additional_reader_kwargs={"sep": ";"},
+        coerce_numeric=[
+            "Cu %", "Au ppm", "Fe %", "S %", "Pb %", "Zn %",
+        ],
+    )
+
+    collar_json = collar_readers.model_dump_json(indent=2)
+    survey_json = survey_readers.model_dump_json(indent=2)
+    assay_json = assay_readers.model_dump_json(indent=2)
+
+    if WRITE_JSON:
+        for name, js in [
+            ("Collar_Mojarra_reader.json", collar_json),
+            ("Survey_Mojarra_reader.json", survey_json),
+            ("Assay_Mojarra_reader.json", assay_json),
+        ]:
+            path = os.path.join(_DATA_PATH, name)
+            with open(path, "w") as f:
+                f.write(js)
+
+        combined = {
+            "collars_reader": json.loads(collar_json),
+            "surveys_reader": json.loads(survey_json),
+            "attrs_reader": json.loads(assay_json),
+        }
+        combined_path = os.path.join(_DATA_PATH, "borehole_import_config.json")
+        with open(combined_path, "w") as f:
+            json.dump(combined, f, indent=2)
+
+    collar2 = GenericReaderFilesHelper.model_validate_json(collar_json)
+    survey2 = GenericReaderFilesHelper.model_validate_json(survey_json)
+    assay2 = GenericReaderFilesHelper.model_validate_json(assay_json)
+
+    assert collar2.file_or_buffer == collar_readers.file_or_buffer
+    assert collar2.encoding == collar_readers.encoding
+    assert collar2.columns_map == collar_readers.columns_map
+    assert survey2.columns_map == survey_readers.columns_map
+    assert assay2.coerce_numeric == assay_readers.coerce_numeric
+    assert assay2.additional_reader_kwargs == assay_readers.additional_reader_kwargs
+
+    borehole_set = read_wells(
+        collars_reader=collar2,
+        surveys_reader=survey2,
+        attrs_reader=assay2,
+        is_lith_attr=False,
+        add_attrs_as_nodes=True,
+    )
+
+    points_attrs = borehole_set.combined_trajectory.data.points_attributes
+    assert "Cu %" in points_attrs.columns
+    assert "Au ppm" in points_attrs.columns
+
+    mr01_id = borehole_set.survey.get_well_num_id("MR01")
+    mr01_attrs = points_attrs[points_attrs["well_id"] == mr01_id]
+    assert not mr01_attrs.empty
+    assert mr01_attrs["Cu %"].dropna().notna().any()
+    assert mr01_attrs["Au ppm"].dropna().notna().any()


### PR DESCRIPTION
[TEST] Add comprehensive tests for Atalaya dataset

- Introduced module `test_atalaya` to validate loading and processing of borehole data (collars, surveys, lithology, assays).
- Verified proper formatting, correctness, and processing using `Collars`, `Survey`, and `BoreholeSet` classes.
- Added checks for attribute mappings, lithology handling, and assay data consistency.

[TEST] Add `test_read_atalaya_assays_via_dict` and utility functions for assay data processing

- Introduced `_df_to_dict` and `_clean_assay_numerics` to handle DataFrame conversions and numeric cleaning for assay data.
- Added `test_read_atalaya_assays_via_dict` to validate assay data integration with `GenericReaderFilesHelper` and `read_wells`.
- Updated `utils_core.py` to improve `get_extension` return consistency.

[TEST] Add diagnostic tests revealing gaps in `read_wells` for raw data handling

- Introduced `TestDiagnosticRawDictGaps` to capture issues in `read_wells` with raw survey and assay data.
- Documented broken behavior with `_correct_angles` crashing on NaN values and skipped interpolations for object dtype columns.
- Added utility function `_make_raw_assay_dict` to streamline raw assay data processing for tests.

[ENH] Fix `read_wells` raw data handling and improve test coverage

- Resolved `_correct_angles` crashes on NaN values by handling missing data in inclination and azimuth corrections.
- Implemented `coerce_numeric` to convert non-numeric assay columns, enabling proper interpolation.
- Updated `read_borehole_interface` to include numeric coercion and drop invalid rows in surveys.
- Enhanced warnings for non-numeric columns skipped during interpolation.
- Added tests to verify corrected behavior for raw survey and assay data ingestion.

[ENH] Refactor `coerce_numeric` to support per-column configuration and update numeric coercion logic

- Extended `coerce_numeric` from a boolean to a column-specific list for greater flexibility in numeric conversion.
- Updated `_coerce_numeric_columns` to iterate only over specified columns, improving performance and precision.
- Enhanced warnings to align with the new `coerce_numeric` configuration approach.
- Revised tests in `test_atalaya` to validate expanded `coerce_numeric` functionality.

[BUG] Simplify reader logic and fix inconsistent handling of `separator`

- Removed redundant `base_kwargs` logic across reader cases.
- Updated reader calls to consistently set `engine='python'`, ensuring compatibility with all configurations.

[TEST] Add round-trip serialization and JSON validation tests for Atalaya readers

- Added `test_atalaya_serialized_json_roundtrip` to validate JSON serialization and deserialization