### PR TITLE
[REF] Simplify attr validation, remove `validate_attr` param, and fix `_filter_numeric_columns` for empty/mixed columns

### DIFF
--- a/subsurface/api/reader/read_wells.py
+++ b/subsurface/api/reader/read_wells.py
@@ -19,8 +19,7 @@ def read_wells(
         is_lith_attr: bool,
         number_nodes: int = 10,
         add_attrs_as_nodes: bool = False,
-        duplicate_attr_depths: bool = False,
-        validate_attr: bool = True,
+        duplicate_attr_depths: bool = False 
 ) -> BoreholeSet:
     # ! FIGUROUT IF WE NEED LITH
     
@@ -48,7 +47,7 @@ def read_wells(
         raise ValueError(f"Error while reading surveys: {e}")
     
     try:
-        attrs: pd.DataFrame = read_attributes(attrs_reader, is_lith=is_lith_attr, validate_attr=validate_attr)
+        attrs: pd.DataFrame = read_attributes(attrs_reader, is_lith=is_lith_attr)
     except Exception as e:
         raise ValueError(f"Error while reading attributes: {e}")
     

--- a/subsurface/core/structs/base_structures/_liquid_earth_mesh.py
+++ b/subsurface/core/structs/base_structures/_liquid_earth_mesh.py
@@ -74,18 +74,14 @@ def _serialize_column(values: np.ndarray) -> bytes:
 
 
 def _filter_numeric_columns(df: pd.DataFrame) -> pd.DataFrame:
-    numeric_cols = {}
+    numeric = []
     for col in df.columns:
         series = df[col]
         if np.issubdtype(series.dtype, np.integer) or np.issubdtype(series.dtype, np.bool_):
-            numeric_cols[col] = series
+            numeric.append(col)
         elif np.issubdtype(series.dtype, np.floating):
-            numeric_cols[col] = series
-        elif series.dtype == object:
-            converted = pd.to_numeric(series, errors='coerce')
-            if converted.notna().sum() >= series.notna().sum():
-                numeric_cols[col] = converted
-    return pd.DataFrame(numeric_cols, index=df.index) if numeric_cols else pd.DataFrame(index=df.index)
+            numeric.append(col)
+    return df[numeric]
 
 
 class LiquidEarthMesh:

--- a/subsurface/core/structs/base_structures/_liquid_earth_mesh.py
+++ b/subsurface/core/structs/base_structures/_liquid_earth_mesh.py
@@ -74,14 +74,20 @@ def _serialize_column(values: np.ndarray) -> bytes:
 
 
 def _filter_numeric_columns(df: pd.DataFrame) -> pd.DataFrame:
-    numeric = []
+    filtered = {}
     for col in df.columns:
         series = df[col]
         if np.issubdtype(series.dtype, np.integer) or np.issubdtype(series.dtype, np.bool_):
-            numeric.append(col)
+            filtered[col] = series
         elif np.issubdtype(series.dtype, np.floating):
-            numeric.append(col)
-    return df[numeric]
+            filtered[col] = series
+        elif series.dtype == object:
+            if not series.notna().any():
+                continue
+            converted = pd.to_numeric(series, errors="coerce")
+            if converted.notna().equals(series.notna()):
+                filtered[col] = converted
+    return pd.DataFrame(filtered, index=df.index)
 
 
 class LiquidEarthMesh:

--- a/subsurface/modules/reader/wells/read_borehole_interface.py
+++ b/subsurface/modules/reader/wells/read_borehole_interface.py
@@ -43,36 +43,19 @@ def read_lith(reader_helper: GenericReaderFilesHelper) -> pd.DataFrame:
 def read_attributes(reader_helper: GenericReaderFilesHelper, is_lith: bool = False, validate_attr: bool = True) -> pd.DataFrame:
     if reader_helper.index_col is False:
         reader_helper.index_col = 0
-
+        
     d = check_format_and_read_to_df(reader_helper)
 
     _map_rows_and_cols_inplace(d, reader_helper)
-
-    if not is_lith:
-        _validate_coerce_numeric_columns(d, reader_helper)
-
     _coerce_numeric_columns(d, reader_helper)
     if validate_attr is False:
         return d
-
+    
     if is_lith:
         d = _validate_lith_data(d, reader_helper)
     else:
-        _validate_attr_dtypes(d)
+        _validate_attr_data(d)
     return d
-
-
-def _validate_coerce_numeric_columns(d: pd.DataFrame, reader_helper: GenericReaderFilesHelper) -> None:
-    if not reader_helper.coerce_numeric:
-        return
-    missing = set(reader_helper.coerce_numeric) - set(d.columns)
-    if missing:
-        names = ", ".join(sorted(missing))
-        raise ValueError(
-            f"attrs_reader.coerce_numeric references columns not present after reading: {names}. "
-            f"Available columns: {list(d.columns)}. "
-            f"Ensure these columns are included in usecols and match the source file headers."
-        )
 
 
 def _coerce_numeric_columns(d: pd.DataFrame, reader_helper: GenericReaderFilesHelper) -> None:
@@ -119,30 +102,9 @@ def _validate_survey_data(d):
     return d_no_singles
 
 
-def _validate_attr_dtypes(d: pd.DataFrame) -> None:
-    if 'base' not in d.columns:
-        raise ValueError(
-            "base column must be present in the attributes file. "
-            "Use columns_map to map a source column to 'base'."
-        )
-
-    structural = {'top', 'base', 'altitude'}
-    assay_cols = [c for c in d.columns if c not in structural]
-
-    non_numeric = []
-    for col in assay_cols:
-        series = d[col]
-        if not (pd.api.types.is_numeric_dtype(series) or pd.api.types.is_bool_dtype(series)):
-            non_numeric.append(col)
-
-    if non_numeric:
-        names = ", ".join(non_numeric)
-        raise ValueError(
-            f"Non-numeric assay columns cannot be imported: {names}. "
-            f"Add these columns to coerce_numeric, preprocess their values "
-            f"(e.g. replace '<0.005' and 'n.a.' with numeric equivalents), "
-            f"or exclude them via usecols."
-        )
+def _validate_attr_data(d):
+    assert d.columns.isin(['base']).any(), ('base column must be present in the file. '
+                                            'Use columns_map to assign column names to these fields.')
 
 
 def _validate_lith_data(d: pd.DataFrame, reader_helper: GenericReaderFilesHelper) -> pd.DataFrame:

--- a/tests/test_interfaces/test_to_binary.py
+++ b/tests/test_interfaces/test_to_binary.py
@@ -4,12 +4,47 @@ from tests.conftest import RequirementsLevel, check_requirements
 
 import pytest
 import numpy as np
+import pandas as pd
 
 from subsurface import UnstructuredData, StructuredData, optional_requirements
+from subsurface.core.structs.base_structures._liquid_earth_mesh import _filter_numeric_columns
 from subsurface.core.structs.unstructured_elements import TriSurf
 from subsurface.modules.reader.read_netcdf import read_unstruct
 from subsurface.modules.reader.profiles.profiles_core import create_mesh_from_trace
 from subsurface.modules.visualization import to_pyvista_mesh_and_texture
+
+
+def test_filter_numeric_columns():
+    source = pd.DataFrame(
+        {
+            "native_integer": pd.Series([1, 2, 3], dtype="int64"),
+            "native_float": pd.Series([1.5, np.nan, 3.5], dtype="float64"),
+            "native_boolean": pd.Series([True, False, True], dtype="bool"),
+            "numeric_object": pd.Series(["1.5", None, "3.5"], dtype=object),
+            "mixed_object": pd.Series(["1.5", "<0.005", None], dtype=object),
+            "text_object": pd.Series(["sand", "clay", None], dtype=object),
+            "empty_object": pd.Series([None, None, None], dtype=object),
+        }
+    )
+
+    result = _filter_numeric_columns(source)
+
+    expected_columns = [
+        "native_integer",
+        "native_float",
+        "native_boolean",
+        "numeric_object",
+    ]
+    assert list(result.columns) == expected_columns
+
+    assert np.issubdtype(result["numeric_object"].dtype, np.floating)
+    expected_values = np.array([1.5, np.nan, 3.5])
+    np.testing.assert_array_almost_equal(
+        result["numeric_object"].to_numpy(), expected_values
+    )
+    assert result["numeric_object"].notna().equals(
+        source["numeric_object"].notna()
+    )
 
 
 @pytest.fixture(scope='module')

--- a/tests/test_interfaces/test_to_binary.py
+++ b/tests/test_interfaces/test_to_binary.py
@@ -4,7 +4,6 @@ from tests.conftest import RequirementsLevel, check_requirements
 
 import pytest
 import numpy as np
-import pandas as pd
 
 from subsurface import UnstructuredData, StructuredData, optional_requirements
 from subsurface.core.structs.unstructured_elements import TriSurf
@@ -95,73 +94,3 @@ def test_profile_to_binary(data_path):
     new_file.write(texture_binary)
 
     return mesh_binary
-
-
-class TestFilterNumericColumns:
-    def test_keeps_numeric_columns_when_mixed_with_object(self):
-        """Regression: object-dtype columns containing only numeric values
-        must be included in _filter_numeric_columns output with a numeric dtype."""
-        from subsurface.core.structs.base_structures._liquid_earth_mesh import _filter_numeric_columns
-
-        df = pd.DataFrame({
-            "well_id": pd.Series([0, 1, 2], dtype=object),
-            "depth": pd.Series([1.5, 2.0, 3.0], dtype=object),
-            "Cu_pct": pd.Series(["4.0", "3.0", "2.0"], dtype=object),
-            "As_pct": pd.Series(["n.a.", "<0.005", "0.001"], dtype=object),
-        })
-
-        result = _filter_numeric_columns(df)
-
-        assert "well_id" in result.columns
-        assert "depth" in result.columns
-        assert "Cu_pct" in result.columns
-        assert "As_pct" not in result.columns
-
-        assert pd.api.types.is_numeric_dtype(result["Cu_pct"])
-        assert result["Cu_pct"].tolist() == [4.0, 3.0, 2.0]
-
-    def test_keeps_mixed_int_float_numeric(self):
-        from subsurface.core.structs.base_structures._liquid_earth_mesh import _filter_numeric_columns
-
-        df = pd.DataFrame({
-            "a": pd.Series([1, 2, 3], dtype=np.int32),
-            "b": pd.Series([1.1, 2.2, 3.3], dtype=np.float64),
-            "c": pd.Series([True, False, True], dtype=bool),
-        })
-
-        result = _filter_numeric_columns(df)
-        assert list(result.columns) == ["a", "b", "c"]
-
-    def test_excludes_all_text_when_no_numeric(self):
-        from subsurface.core.structs.base_structures._liquid_earth_mesh import _filter_numeric_columns
-
-        df = pd.DataFrame({
-            "text": pd.Series(["foo", "bar", "baz"], dtype=object),
-        })
-
-        result = _filter_numeric_columns(df)
-        assert result.empty
-
-    def test_round_trip_unstructured_data_with_mixed_attrs(self):
-        df_vertex = pd.DataFrame({
-            "well_id": pd.Series([0, 0, 1, 1], dtype=object),
-            "depth": pd.Series([0.0, 1.0, 0.0, 1.0], dtype=object),
-            "Cu_pct": pd.Series([4.0, 3.0, 2.0, 1.0], dtype=object),
-            "notes": pd.Series(["", "", "lost", ""], dtype=object),
-        })
-
-        unstr = UnstructuredData.from_array(
-            vertex=np.array([[0, 0, 0], [0, 0, 1], [1, 0, 0], [1, 0, 1]], dtype=np.float32),
-            cells=np.array([[0, 1], [2, 3]], dtype=np.int32),
-            vertex_attr=df_vertex,
-        )
-
-        header = unstr._set_binary_header()
-        attr_names = [m["name"] for m in header["vertex_attrs"]]
-        assert "well_id" in attr_names
-        assert "depth" in attr_names
-        assert "Cu_pct" in attr_names
-        assert "notes" not in attr_names
-
-        binary = unstr.to_binary()
-        assert len(binary) > 0

--- a/tests/test_io/test_lines/test_atalaya.py
+++ b/tests/test_io/test_lines/test_atalaya.py
@@ -369,13 +369,6 @@ class TestDiagnosticRawDictGaps:
            raw assay with coerce_numeric=True now interpolates correctly.
     """
 
-    _ALL_ASSAY_COLS = [
-        "Cu %", "S %", "Pb %", "Zn %", "As %", "Sb %", "Bi %",
-        "Hg ppm", "Fe %", "Th  ppm", "Ag ppm", "Cd %",
-        "Co %", "Ni %", "Mn %", "Al %", "Ca %", "Mg %",
-        "Sn ppm", "Mo %", "P %", "Tl %", "Au ppm",
-    ]
-
     def test_raw_survey_no_longer_crashes(self):
         raw_survey = pd.read_csv(
             os.path.join(_DATA_PATH, "Survey_Mojarra.csv"),
@@ -398,9 +391,9 @@ class TestDiagnosticRawDictGaps:
         attr_reader = GenericReaderFilesHelper(
             file_or_buffer=_make_raw_assay_dict(),
             columns_map={"HoleID": "id", "From": "top", "To": "base"},
-            coerce_numeric=self._ALL_ASSAY_COLS,
         )
 
+        # Previously crashed in _correct_angles, now succeeds.
         borehole_set = read_wells(
             collars_reader=collar_reader,
             surveys_reader=survey_reader,
@@ -437,14 +430,20 @@ class TestDiagnosticRawDictGaps:
             columns_map={"HoleID": "id", "From": "top", "To": "base"},
         )
 
-        with pytest.raises(ValueError, match="Non-numeric assay columns cannot be imported"):
-            read_wells(
+        with pytest.warns(UserWarning, match="non-numeric dtype"):
+            borehole_set = read_wells(
                 collars_reader=collar_reader,
                 surveys_reader=survey_reader,
                 attrs_reader=attr_reader,
                 is_lith_attr=False,
                 add_attrs_as_nodes=True,
             )
+
+        points_attrs = borehole_set.combined_trajectory.data.points_attributes
+        assert "Cu %" in points_attrs.columns
+        assert points_attrs["Cu %"].isna().all()
+        assert "Au ppm" in points_attrs.columns
+        assert points_attrs["Au ppm"].isna().all()
 
     def test_raw_assay_with_coerce_numeric_works(self):
         raw_survey = pd.read_csv(
@@ -519,9 +518,6 @@ def test_atalaya_serialized_json_roundtrip():
         file_or_buffer=os.path.join(_DATA_PATH, "Assay_Mojarra.csv"),
         columns_map={"HoleID": "id", "From": "top", "To": "base"},
         additional_reader_kwargs={"sep": ";"},
-        usecols=[
-            "HoleID", "From", "To", "Cu %", "Au ppm", "Fe %", "S %", "Pb %", "Zn %",
-        ],
         coerce_numeric=[
             "Cu %", "Au ppm", "Fe %", "S %", "Pb %", "Zn %",
         ],

--- a/tests/test_io/test_lines/test_lines_I.py
+++ b/tests/test_io/test_lines/test_lines_I.py
@@ -156,8 +156,7 @@ def test_read_assay():
         surveys_reader=reader,
         attrs_reader=reader_attr,
         is_lith_attr=False,
-        add_attrs_as_nodes=True,
-        validate_attr=False,
+        add_attrs_as_nodes=True
     )
     assert borehole_set.collars.collar_loc.n_points > 0
     assert borehole_set.survey.survey_trajectory.data.n_points > 0

--- a/tests/test_io/test_lines/test_lines_V.py
+++ b/tests/test_io/test_lines/test_lines_V.py
@@ -177,7 +177,7 @@ def test_read():
             },
             encoding="latin-1",
             additional_reader_kwargs={"decimal": ","}
-        ), validate_attr=False)
+        ))
     assert not attributes.empty
 
     lith: pd.DataFrame = read_lith(

--- a/tests/test_io/test_lines/test_supersimple_reading.py
+++ b/tests/test_io/test_lines/test_supersimple_reading.py
@@ -29,8 +29,7 @@ def test_read_supersimple_borehole_data(data_path):
         collars_reader=collars_reader,
         surveys_reader=surveys_reader,
         attrs_reader=attrs_reader,
-        is_lith_attr=False,
-        validate_attr=False,
+        is_lith_attr=False
     )
 
     # Verification


### PR DESCRIPTION
[REVERT] Undo global assay dtype enforcement from df33620

Breaking refactor removed: global _validate_attr_dtypes (now back to permissive
base-only _validate_attr_data), _validate_coerce_numeric_columns, implicit
object-to-numeric conversion in LiquidEarth _filter_numeric_columns, and the
read_wells(validate_attr=) API opt-out.

Atalaya numeric coercion remains supported through explicit coerce_numeric
configuration on reader helpers. The binary round-trip regression test from
26fc831 confirms coerced assay columns survive serialization and
deserialization with valid non-null values.

[ENH] Extend `_filter_numeric_columns` to handle object-dtype numeric conversion and add corresponding test

- Enhanced `_filter_numeric_columns` to process object-dtype columns with numeric-like values, ensuring accurate conversion to numeric dtype.
- Included new test case to validate functionality across diverse input scenarios, including mixed and empty object fields.